### PR TITLE
Fix for Task #78. Normalize component identifier casing using Locale.ROOT in addComponentIdentifier method.

### DIFF
--- a/approov-service/src/main/java/io/approov/util/sig/SignatureParameters.java
+++ b/approov-service/src/main/java/io/approov/util/sig/SignatureParameters.java
@@ -5,6 +5,7 @@ import androidx.annotation.NonNull;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import io.approov.util.http.sfv.Dictionary;
@@ -253,7 +254,7 @@ public class SignatureParameters implements Cloneable {
 	 */
 	public SignatureParameters addComponentIdentifier(String identifier) {
 		if (!identifier.startsWith("@")) {
-			componentIdentifiers.add(StringItem.valueOf(identifier.toLowerCase()));
+			componentIdentifiers.add(StringItem.valueOf(identifier.toLowerCase(Locale.US)));
 		} else {
 			componentIdentifiers.add(StringItem.valueOf(identifier));
 		}


### PR DESCRIPTION
Fix #78