### PR TITLE
Feature/dont wrap on missing ipk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this package will be documented in this file.
 
 The format is based on Keep a Changelog and this project adheres to Semantic Versioning.
 
+
 ## [3.5.5] - 2026-03-25
 
 ### Added
@@ -18,6 +19,7 @@ The format is based on Keep a Changelog and this project adheres to Semantic Ver
 ### Fixed
 - Prevented exceptions when key-pair generation fails. The service now logs an error and continues without the install message signature, allowing the backend to decide whether to reject the request. (inherited from shared sdk update)
 - Memory leak fix in pinned handshake cache using LinkedHashSet.
+- Initialized the Retrofit instance cache statically to avoid `NullPointerException` when `setOkHttpClientBuilder` or `getRetrofit` are called before `initialize`.
 ### Deprecated
 - ApproovInterceptorExtensions in favor of ApproovServiceMutator.
 - setProceedOnNetworkFail() and getProceedOnNetworkFail() in favor of setServiceMutator.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+All notable changes to this package will be documented in this file.
+
+The format is based on Keep a Changelog and this project adheres to Semantic Versioning.
+
+## [3.5.5] - 2026-03-25
+
+### Added
+- ApproovServiceMutator protocol with default behavior to centralize decision points in the service flow.
+- Mutator hooks for precheck, token fetch, secure string fetch, custom JWT fetch, interceptor decisions, and pinning.
+- REFERENCE.md & CHANGELOG.md & USAGE.md
+- Added `setUseApproovStatusIfNoToken` to allow using status as token value when token is missing.
+### Changed
+- ApproovService now routes decision logic through the service mutator and exposes set/get APIs.
+- Pinning logic is now applied via `ApproovPinningInterceptor` which checks `ApproovServiceMutator.handlePinningShouldProcessRequest`.
+- Update version to 3.5.5
+### Fixed
+- Prevented exceptions when key-pair generation fails. The service now logs an error and continues without the install message signature, allowing the backend to decide whether to reject the request. (inherited from shared sdk update)
+- Memory leak fix in pinned handshake cache using LinkedHashSet.
+### Deprecated
+- ApproovInterceptorExtensions in favor of ApproovServiceMutator.
+- setProceedOnNetworkFail() and getProceedOnNetworkFail() in favor of setServiceMutator.
+- prefetch() is now automatically called when the service is initialized.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,18 @@ A wrapper for the [Approov SDK](https://github.com/approov/approov-android-sdk) 
 
 See [Java](https://github.com/approov/quickstart-android-java-retrofit) and [Kotlin](https://github.com/approov/quickstart-android-kotlin-retrofit) quickstarts for instructions on how to use this.
 
+# Changelog
+
+Please see the [CHANGELOG.md](CHANGELOG.md) for more information on the changes in each version.
+
+# Reference
+
+Please see the [REFERENCE.md](REFERENCE.md) for more information on the Approov Service for Retrofit.
+
+# Usage
+
+Please see the [USAGE.md](USAGE.md) for more information on how to use this wrapper.
+
 ## Included 3rd party Source
 
 To support message signing, this repo has adapted code released by two 3rd

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1,0 +1,435 @@
+# Reference
+This provides a reference for all of the static methods defined on `ApproovService`. These are available if you import:
+
+**Java:**
+```Java
+import io.approov.service.retrofit.ApproovService;
+```
+
+**Kotlin:**
+```kotlin
+import io.approov.service.retrofit.ApproovService
+```
+
+Various methods may throw an `ApproovException` if there is a problem. The method `getMessage()` provides a descriptive message.
+
+If a method throws an `ApproovNetworkException` (a subclass of `ApproovFetchStatusException`) then this indicates the problem was caused by a networking issue, and a user initiated retry should be allowed.
+
+If a method throws an `ApproovRejectionException` (a subclass of `ApproovFetchStatusException`) the this indicates the problem was that the app failed attestation. An additional method `getARC()` provides the [Attestation Response Code](https://approov.io/docs/latest/approov-usage-documentation/#attestation-response-code), which could be provided to the user for communication with your app support to determine the reason for failure, without this being revealed to the end user. The method `getRejectionReasons()` provides the [Rejection Reasons](https://approov.io/docs/latest/approov-usage-documentation/#rejection-reasons) if the feature is enabled, providing a comma separated list of reasons why the app attestation was rejected.
+
+## initialize
+Initializes the Approov SDK and thus enables the Approov features. The `config` will have been provided in the initial onboarding or email or can be [obtained](https://approov.io/docs/latest/approov-usage-documentation/#getting-the-initial-sdk-configuration) using the approov CLI. This will generate an error if a second attempt is made at initialization with a different `config`.
+
+**Java:**
+```Java
+void initialize(Context context, String config)
+```
+
+**Kotlin:**
+```kotlin
+fun initialize(context: Context, config: String)
+```
+
+The [application context](https://developer.android.com/reference/android/content/Context#getApplicationContext()) must be provided using the `context` parameter.
+
+It is possible to pass an empty `config` string to indicate that no initialization is required. Only do this if you are also using a different Approov service layer in your app (which will use the same underlying Approov SDK) and this will have been initialized first.
+
+An alternative initialization function allows to provide further options in the `comment` parameter. Please refer to the [Approov SDK documentation](https://approov.io/docs/latest/approov-direct-sdk-integration/#sdk-initialization-options) for details.
+
+**Java:**
+```java
+void initialize(Context context, String config, String comment)
+```
+
+**Kotlin:**
+```kotlin
+fun initialize(context: Context, config: String, comment: String)
+```
+
+## setApproovInterceptorExtensions
+
+**OBSOLETED**: Use `setServiceMutator` instead.
+
+Sets the interceptor extensions callback handler. This facility supports message signing that is independent from the rest of the attestation flow. The default ApproovService layer issues no callbacks. Provide a non-null handler to add functionality to the attestation flow. The configuration used to control installation message signing is passed in the `callbacks` parameter. The behavior of the provided configuration must remain constant while in use by the ApproovService. Passing `null` to this method will disable message signing.
+
+**Java:**
+```java
+void setApproovInterceptorExtensions(ApproovServiceMutator callbacks)
+```
+
+**Kotlin:**
+```kotlin
+fun setApproovInterceptorExtensions(callbacks: ApproovServiceMutator)
+```
+
+Provide an ApproovDefaultMessageSigning object instantiated as shown below to enable installation message signing:
+
+**Java:**
+```java
+    ApproovService.setApproovInterceptorExtensions(
+        new ApproovDefaultMessageSigning().setDefaultFactory(
+            ApproovDefaultMessageSigning.generateDefaultSignatureParametersFactory()));
+```
+
+**Kotlin:**
+```kotlin
+    ApproovService.setApproovInterceptorExtensions(
+        ApproovDefaultMessageSigning().setDefaultFactory(
+            ApproovDefaultMessageSigning.generateDefaultSignatureParametersFactory()))
+```
+
+This default setup provides a basic signature mechanism that is not specific to the requests that are issued by an app.
+
+The default signature parameter factory returned by `ApproovDefaultMessageSigning.generateDefaultSignatureParametersFactory` can be customized by calling further methods. Please refer to the code for the `SignatureParametersFactory` class in the [approov-service-retrofit](https://github.com/approov/approov-service-retrofit) repository's [`ApproovDefaultMessageSigning.java`](https://github.com/approov/approov-service-retrofit/blob/main/approov-service/src/main/java/io/approov/service/retrofit/ApproovDefaultMessageSigning.java) source file for information on the available options. Alternatively, you can extend the `SignatureParametersFactory` class and provide an object of the derived class as the argument to `ApproovDefaultMessageSigning().setDefaultFactory`.
+
+Additionally, you can provide a custom implementation of the [`ApproovServiceMutator`](https://github.com/approov/approov-service-retrofit/blob/main/approov-service/src/main/java/io/approov/service/retrofit/ApproovServiceMutator.java) interface to have full control of the message signing. Please see the implementation of the class `ApproovDefaultMessageSigning` in [`ApproovDefaultMessageSigning.java`](https://github.com/approov/approov-service-retrofit/blob/main/approov-service/src/main/java/io/approov/service/retrofit/ApproovDefaultMessageSigning.java) for an example.
+
+## getRetrofit
+Gets a Retrofit instance that enables the Approov service. The builder for Retrofit should be provided to allow its customization. This simply adds the underlying OkHttpClient to be used. Approov tokens are added in headers to requests, and connections are also pinned. Retrofit instances are added lazily on demand but are cached if there is no change.
+
+**Java:**
+```Java
+Retrofit getRetrofit(Retrofit.Builder builder)
+```
+
+**Kotlin:**
+```kotlin
+fun getRetrofit(builder: Retrofit.Builder): Retrofit
+```
+
+If Approov has not been initialized, then this provides a Retrofit processing requests without any Approov protection.
+
+## setOkHttpClientBuilder
+Sets the `OkHttpClient.Builder` to be used for constructing the default Approov `OkHttpClient` underlying the Retrofit instance. This allows a custom configuration to be set, with additional interceptors and properties. This clears the cached Retrofit client instances so should only be called when an actual builder change is required.
+
+**Java:**
+```Java
+void setOkHttpClientBuilder(OkHttpClient.Builder builder)
+```
+
+**Kotlin:**
+```kotlin
+fun setOkHttpClientBuilder(builder: OkHttpClient.Builder)
+```
+
+## setProceedOnNetworkFail
+If the provided `proceed` value is `true` then this indicates that the network interceptor should proceed anyway if it is not possible to obtain an Approov token due to a networking failure. If this is called then the backend API can receive calls without the expected Approov token header being added, or without header/query parameter substitutions being made. This should only ever be used if there is some particular reason, perhaps due to local network conditions, that you believe that traffic to the Approov cloud service will be particularly problematic.
+
+**Java:**
+```Java
+void setProceedOnNetworkFail(boolean proceed)
+```
+
+**Kotlin:**
+```kotlin
+fun setProceedOnNetworkFail(proceed: Boolean)
+```
+
+**OBSOLETED**: Use `setServiceMutator` instead to control this behavior.
+
+
+Note that this should be used with *CAUTION* because it may allow a connection to be established before any dynamic pins have been received via Approov, thus potentially opening the channel to a MitM.
+
+## setUseApproovStatusIfNoToken
+If the provided `shouldUse` value is `true` then this indicates that the Approov fetch status (e.g. "NO_NETWORK", "MITM_DETECTED") should be used as the token header value if the actual token fetch fails or returns an empty token. This allows passing error condition information to the backend via the Approov-Token header, which might otherwise be empty or missing.
+
+**Java:**
+```Java
+void setUseApproovStatusIfNoToken(boolean shouldUse)
+```
+
+**Kotlin:**
+```kotlin
+fun setUseApproovStatusIfNoToken(shouldUse: Boolean)
+```
+
+## setDevKey
+[Sets a development key](https://approov.io/docs/latest/approov-usage-documentation/#using-a-development-key) in order to force an app to be passed. This can be used if the app has to be resigned in a test environment and would thus fail attestation otherwise.
+
+**Java:**
+```Java
+void setDevKey(String devKey)
+```
+
+**Kotlin:**
+```kotlin
+fun setDevKey(devKey: String)
+```
+
+## setApproovHeader
+Sets the `header` that the Approov token is added on, as well as an optional `prefix` String (such as "`Bearer `"). Set `prefix` to the empty string if it is not required. By default the token is provided on `Approov-Token` with no prefix.
+
+**Java:**
+```Java
+void setApproovHeader(String header, String prefix)
+```
+
+**Kotlin:**
+```kotlin
+fun setApproovHeader(header: String, prefix: String?)
+```
+
+## setBindingHeader
+Sets a binding `header` that may be present on requests being made. This is for the [token binding](https://approov.io/docs/latest/approov-usage-documentation/#token-binding) feature. A header should be chosen whose value is unchanging for most requests (such as an Authorization header). If the `header` is present, then a hash of the `header` value is included in the issued Approov tokens to bind them to the value. This may then be verified by the backend API integration.
+
+**Java:**
+```Java
+void setBindingHeader(String header)
+```
+
+**Kotlin:**
+```kotlin
+fun setBindingHeader(header: String)
+```
+
+## addSubstitutionHeader
+Adds the name of a `header` which should be subject to [secure strings](https://approov.io/docs/latest/approov-usage-documentation/#secure-strings) substitution. This means that if the `header` is present then the value will be used as a key to look up a secure string value which will be substituted into the `header` value instead. This allows easy migration to the use of secure strings. A `requiredPrefix` may be specified to deal with cases such as the use of "`Bearer `" prefixed before values in an authorization header. Set `requiredPrefix` to `null` if it is not required. Note that this function should be called on initialization rather than for every request as it will require a new OkHttpClient to be built.
+
+**Java:**
+```Java
+void addSubstitutionHeader(String header, String requiredPrefix)
+```
+
+**Kotlin:**
+```kotlin
+fun addSubstitutionHeader(header: String, requiredPrefix: String?)
+```
+
+## removeSubstitutionHeader
+Removes a `header` previously added using `addSubstitutionHeader`.
+
+**Java:**
+```Java
+void removeSubstitutionHeader(String header)
+```
+
+**Kotlin:**
+```kotlin
+fun removeSubstitutionHeader(header: String)
+```
+
+## addSubstitutionQueryParam
+Adds a `key` name for a query parameter that should be subject to [secure strings](https://approov.io/docs/latest/approov-usage-documentation/#secure-strings) substitution. This means that if the query parameter is present in a URL then the value will be used as a key to look up a secure string value which will be substituted as the query parameter value instead. This allows easy migration to the use of secure strings. Note that this function should be called on initialization rather than for every request as it will require a new OkHttpClient to be built.
+
+**Java:**
+```Java
+void addSubstitutionQueryParam(String key)
+```
+
+**Kotlin:**
+```kotlin
+fun addSubstitutionQueryParam(key: String)
+```
+
+## removeSubstitutionQueryParam
+Removes a query parameter `key` name previously added using `addSubstitutionQueryParam`.
+
+**Java:**
+```Java
+void removeSubstitutionQueryParam(String key)
+```
+
+**Kotlin:**
+```kotlin
+fun removeSubstitutionQueryParam(key: String)
+```
+
+## addExclusionURLRegex
+Adds an exclusion URL [regular expression](https://regex101.com/) via the `urlRegex` parameter. If a URL for a request matches this regular expression then it will not be subject to any Approov protection. Note that this function should be called on initialization rather than for every request as it will require a new OkHttpClient to be built.
+
+**Java:**
+```Java
+void addExclusionURLRegex(String urlRegex)
+```
+
+**Kotlin:**
+```kotlin
+fun addExclusionURLRegex(urlRegex: String)
+```
+
+Note that this facility must be used with *EXTREME CAUTION* due to the impact of dynamic pinning. Pinning may be applied to all domains added using Approov, and updates to the pins are received when an Approov fetch is performed. If you exclude some URLs on domains that are protected with Approov, then these will be protected with Approov pins but without a path to update the pins until a URL is used that is not excluded. Thus you are responsible for ensuring that there is always a possibility of calling a non-excluded URL, or you should make an explicit call to fetchToken if there are persistent pinning failures. Conversely, use of those option may allow a connection to be established before any dynamic pins have been received via Approov, thus potentially opening the channel to a MitM.
+
+## removeExclusionURLRegex
+Removes an exclusion URL regular expression (`urlRegex`) previously added using `addExclusionURLRegex`.
+
+**Java:**
+```Java
+void removeExclusionURLRegex(String urlRegex)
+```
+
+**Kotlin:**
+```kotlin
+fun removeExclusionURLRegex(urlRegex: String)
+```
+
+## prefetch
+Allows an Approov fetch operation to be performed as early as possible. This permits a token or secure strings to be available while an application might be loading resources or is awaiting user input. Since the initial fetch is the most expensive the prefetch can hide the most latency.
+
+**DEPRECATED**: This method is now automatically called when the service is initialized.
+
+**Java:**
+```Java
+void prefetch()
+```
+
+**Kotlin:**
+```kotlin
+fun prefetch()
+```
+
+## precheck
+Performs a precheck to determine if the app will pass attestation. This requires [secure strings](https://approov.io/docs/latest/approov-usage-documentation/#secure-strings) to be enabled for the account, although no strings need to be set up. 
+
+**Java:**
+```Java
+void precheck() throws ApproovException
+```
+
+**Kotlin:**
+```kotlin
+@Throws(ApproovException::class)
+fun precheck()
+```
+
+This throws `ApproovException` if the precheck failed. This will likely require network access so may take some time to complete, and should not be called from the UI thread.
+
+## getDeviceID
+Gets the [device ID](https://approov.io/docs/latest/approov-usage-documentation/#extracting-the-device-id) used by Approov to identify the particular device that the SDK is running on. Note that different Approov apps on the same device will return a different ID. Moreover, the ID may be changed by an uninstall and reinstall of the app.
+
+**Java:**
+```Java
+String getDeviceID() throws ApproovException
+```
+
+**Kotlin:**
+```kotlin
+@Throws(ApproovException::class)
+fun getDeviceID(): String
+```
+
+This throws `ApproovException` if there was a problem obtaining the device ID.
+
+## setDataHashInToken
+Directly sets the [token binding](https://approov.io/docs/latest/approov-usage-documentation/#token-binding) hash to be included in subsequently fetched Approov tokens. If the hash is different from any previously set value then this will cause the next token fetch operation to fetch a new token with the correct payload data hash. The hash appears in the `pay` claim of the Approov token as a base64 encoded string of the SHA256 hash of the data. Note that the data is hashed locally and never sent to the Approov cloud service. This is an alternative to using `setBindingHeader` and you should not use both methods at the same time.
+
+**Java:**
+```Java
+void setDataHashInToken(String data) throws ApproovException
+```
+
+**Kotlin:**
+```kotlin
+@Throws(ApproovException::class)
+fun setDataHashInToken(data: String)
+```
+
+This throws `ApproovException` if there was a problem changing the data hash.
+
+## fetchToken
+Performs an Approov token fetch for the given `url`. This should be used in situations where it is not possible to use the networking interception to add the token. Note that the returned token should NEVER be cached by your app, you should call this function when it is needed.
+
+**Java:**
+```Java
+String fetchToken(String url) throws ApproovException
+```
+
+**Kotlin:**
+```kotlin
+@Throws(ApproovException::class)
+fun fetchToken(url: String): String
+```
+
+This throws `ApproovException` if there was a problem obtaining an Approov token. This may require network access so may take some time to complete, and should not be called from the UI thread.
+
+## getMessageSignature
+**DEPRECATED**, replaced by `getAccountMessageSignature`.
+
+**Java:**
+```Java
+String getMessageSignature(String message) throws ApproovException
+```
+
+**Kotlin:**
+```kotlin
+@Throws(ApproovException::class)
+fun getMessageSignature(message: String): String
+```
+
+## getAccountMessageSignature
+Gets the [account message signature](https://approov.io/docs/latest/approov-usage-documentation/#account-message-signing) for the given message. This is returned as a base64 encoded signature. This feature uses an account specific message signing key that is transmitted to the SDK after a successful fetch if the facility is enabled for the account. Note that if the attestation failed then the signing key provided is actually random so that the signature will be incorrect. An Approov token should always be included in the message being signed and sent alongside this signature to prevent replay attacks.
+    
+**Java:**
+```java
+String getAccountMessageSignature(String message) throws ApproovException
+```
+
+**Kotlin:**
+```kotlin
+@Throws(ApproovException::class)
+fun getAccountMessageSignature(message: String): String
+```
+
+This throws `ApproovException` if no signature is available, because there has been no prior fetch or the feature is not enabled.
+
+## getInstallMessageSignature
+Gets the [install message signature](https://approov.io/docs/latest/approov-usage-documentation/#installation-message-signing) for the given message. This is returned as the base64 encoding of the signature in ASN.1 DER format. This feature uses an app install specific message signing key that is generated the first time an app launches. This signing mechanism uses an ECC key pair where the private key is managed by the secure element or trusted execution environment of the device. Where it can, Approov uses attested key pairs to perform the message signing. An Approov token should always be included in the message being signed and sent alongside this signature to prevent replay attacks.
+
+**Java:**
+```java
+public static String getInstallMessageSignature(String message) throws ApproovException
+```
+
+**Kotlin:**
+```kotlin
+@Throws(ApproovException::class)
+fun getInstallMessageSignature(message: String): String
+```
+
+This throws `ApproovException` if no signature is available, because there has been no prior fetch or the feature is not enabled.
+
+## fetchSecureString
+Fetches a [secure string](https://approov.io/docs/latest/approov-usage-documentation/#secure-strings) with the given `key` if `newDef` is `null`. Returns `null` if the `key` secure string is not defined. If `newDef` is not `null` then a secure string for the particular app instance may be defined. In this case the new value is returned as the secure string. Use of an empty string for `newDef` removes the string entry. Note that the returned string should NEVER be cached by your app, you should call this function when it is needed.
+
+**Java:**
+```Java
+String fetchSecureString(String key, String newDef) throws ApproovException
+```
+
+**Kotlin:**
+```kotlin
+@Throws(ApproovException::class)
+fun fetchSecureString(key: String, newDef: String?): String?
+```
+
+This throws `ApproovException` if there was a problem obtaining the secure string. This may require network access so may take some time to complete, and should not be called from the UI thread.
+
+## fetchCustomJWT
+Fetches a [custom JWT](https://approov.io/docs/latest/approov-usage-documentation/#custom-jwts) with the given marshaled JSON `payload`.
+
+**Java:**
+```Java
+String fetchCustomJWT(String payload) throws ApproovException
+```
+
+**Kotlin:**
+```kotlin
+@Throws(ApproovException::class)
+fun fetchCustomJWT(payload: String): String
+```
+
+This throws `ApproovException` if there was a problem obtaining the custom JWT. This may require network access so may take some time to complete, and should not be called from the UI thread.
+
+## getLastARC
+Obtains the last [Attestation Response Code](https://ext.approov.io/docs/latest/approov-usage-documentation/#attestation-response-code) provided a network request to the Approov servers has succeeded. 
+
+**Java:**
+```Java
+String getLastARC()
+```
+
+**Kotlin:**
+```kotlin
+fun getLastARC(): String
+```
+
+In the event of no network available this function returns an empty string. This function should be used with *CAUTION* and instead rely on a customized error response from the server which includes the `ARC` code if one is available.

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -48,7 +48,9 @@ fun initialize(context: Context, config: String, comment: String)
 
 ## setApproovInterceptorExtensions
 
-**OBSOLETED**: Use `setServiceMutator` instead.
+**OBSOLETED COMPATIBILITY API**: Use `setServiceMutator` instead for all new integrations, including message signing.
+
+This method is retained only as a compatibility alias for existing integrations. It delegates to `setServiceMutator`. Prefer `setServiceMutator` directly so your code matches the current mutator-based API surface and documentation.
 
 Sets the interceptor extensions callback handler. This facility supports message signing that is independent from the rest of the attestation flow. The default ApproovService layer issues no callbacks. Provide a non-null handler to add functionality to the attestation flow. The configuration used to control installation message signing is passed in the `callbacks` parameter. The behavior of the provided configuration must remain constant while in use by the ApproovService. Passing `null` to this method will disable message signing.
 
@@ -62,7 +64,7 @@ void setApproovInterceptorExtensions(ApproovServiceMutator callbacks)
 fun setApproovInterceptorExtensions(callbacks: ApproovServiceMutator)
 ```
 
-Provide an ApproovDefaultMessageSigning object instantiated as shown below to enable installation message signing:
+Legacy equivalent using the obsolete alias:
 
 **Java:**
 ```java
@@ -74,6 +76,22 @@ Provide an ApproovDefaultMessageSigning object instantiated as shown below to en
 **Kotlin:**
 ```kotlin
     ApproovService.setApproovInterceptorExtensions(
+        ApproovDefaultMessageSigning().setDefaultFactory(
+            ApproovDefaultMessageSigning.generateDefaultSignatureParametersFactory()))
+```
+
+Preferred current usage:
+
+**Java:**
+```java
+    ApproovService.setServiceMutator(
+        new ApproovDefaultMessageSigning().setDefaultFactory(
+            ApproovDefaultMessageSigning.generateDefaultSignatureParametersFactory()));
+```
+
+**Kotlin:**
+```kotlin
+    ApproovService.setServiceMutator(
         ApproovDefaultMessageSigning().setDefaultFactory(
             ApproovDefaultMessageSigning.generateDefaultSignatureParametersFactory()))
 ```

--- a/USAGE.md
+++ b/USAGE.md
@@ -61,9 +61,11 @@ class EnforceTokenMutator : ApproovServiceMutator {
 
 ### Allow Access Without Token (Optional)
 
-Conversely, if the device could not obtain proof of attestation, for example because of a `POOR_NETWORK` or `NO_NETWORK` response from the SDK, the default behavior is to cancel the request to your API. However, you might prefer to let the request attempt the connection to your backend without the Approov Token to allow for server-side handling (e.g., returning a custom 401/403).
+Conversely, if the device could not obtain proof of attestation, for example because of a `POOR_NETWORK` or `NO_NETWORK` response from the SDK, the default behavior is to cancel the request to your API. However, you might prefer to let the request attempt the connection to your backend without a valid Approov token to allow for server-side handling (e.g., returning a custom 401/403).
 
-To implement this, check for `POOR_NETWORK` and return `false`, which proceeds without the token validation (skips adding token).
+To implement this, check for `POOR_NETWORK` and return `false`, which proceeds without requiring a valid token fetch.
+
+If `ApproovService.setUseApproovStatusIfNoToken(true)` is enabled, then proceeding without a valid token may still add the `Approov-Token` header with the fetch status value, such as `POOR_NETWORK` or `MITM_DETECTED`. This gives your backend explicit context about why the request continued without a real token.
 
 ```kotlin
     if (approovResults.status == Approov.TokenFetchStatus.POOR_NETWORK) {
@@ -116,9 +118,9 @@ ApproovService.setServiceMutator(MyMutator()) // Install custom implementation o
 
 ## Approov Token Fallback Status
 
-If the SDK cannot obtain a valid Approov token (e.g., due to a `NO_NETWORK` or `MITM_DETECTED` state), the request traditionally proceeds without the `Approov-Token` header or fails entirely depending on the current policy. To give your backend visibility into *why* there is no token, you can use `ApproovService.setUseApproovStatusIfNoToken(true)`.
+If the SDK cannot obtain a valid Approov token (e.g., due to a `NO_NETWORK`, `MITM_DETECTED`, or `NO_APPROOV_SERVICE` state), the request may either fail or continue depending on the active mutator policy. To give your backend visibility into *why* a real token could not be added, you can use `ApproovService.setUseApproovStatusIfNoToken(true)`.
 
-When enabled, the service will inject the Approov fetch status directly into the `Approov-Token` header if the actual token fetch fails or is empty. Your backend can then distinguish between a request that was sent without a token due to an attacker stripping it, versus a legitimate request that encountered a specific failure like `POOR_NETWORK`. 
+When enabled, the service injects the Approov fetch status directly into the `Approov-Token` header whenever the request is still allowed to proceed but no real token is available. Your backend can then distinguish between a request that was sent without a token due to an attacker stripping it, versus a legitimate request that encountered a specific failure like `POOR_NETWORK` or `MITM_DETECTED`.
 
 Please note that this behavior is conditional upon the configuration of your `ApproovServiceMutator`. If your mutator explicitly throws an error or aborts the request entirely for a particular status (for example, throwing an exception on `NO_NETWORK`), the request will never proceed to the server, and this status fallback feature will effectively not be used for that specific case.
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -1,0 +1,262 @@
+# Usage
+
+This document describes the features and functionality of the Approov Service for Retrofit. It provides details on how to interact with the service layer and customize its behavior to suit your application's needs, specifically through the `ApproovServiceMutator`. For a basic integration example, please refer to the [Quickstart guide](https://github.com/approov/quickstart-android-kotlin-retrofit).
+
+# Approov Service Mutator
+
+The `ApproovServiceMutator` allows you to customize the behavior of the Approov Retrofit layer at key points in the request lifecycle. You can override specific methods to tailor the handling of attestations and requests while retaining the default behavior for other cases.
+
+## Why use a mutator
+
+- Centralize app-specific policy without forking the service layer.
+- Add telemetry on rejections or network failures.
+- Skip Approov processing for health checks or local endpoints.
+- Customize pinning decisions per request.
+- Adjust behavior when token or secure string fetches fail.
+
+## Default Behavior
+
+By default, the `ApproovService` processes requests based on the attestation status. It relies on the underlying SDK to provide a proof of attestation, which is a cryptographically signed JWT token. Requesting this attestation typically returns the token immediately; however, a network connection to the Approov cloud is required upon app launch or when the token is nearing expiration. Note that the SDK only knows if an attestation token has been obtained; it cannot determine if the token is valid (validity is checked by your backend). The default behavior is described in more detail in the official documentation section [Approov Token Fetch Results](https://approov.io/docs/latest/approov-usage-documentation/#approov-token-fetch-results) and is summarized in the table below:
+
+| Approov Fetch Status | Action | Result |
+| :--- | :--- | :--- |
+| **Success** | Proceed | The request acts as expected and is sent with the `Approov-Token`. |
+| **No Network / Poor Network** | Throw Exception | An `ApproovNetworkException` is thrown. The request should be retried. |
+| **Rejection** | Throw Exception | An `ApproovRejectionException` is thrown. The request is marked as rejected. |
+| **No Approov Service / Unknown URL** | Proceed | The request is sent **without** an `Approov-Token`. |
+
+## Customizing Request Handling with Mutators
+
+You may want to modify this behavior to suit specific app requirements. A common use case is handling `NO_APPROOV_SERVICE` statuses.
+
+### Prevent Access Without a Token (e.g. NO_APPROOV_SERVICE)
+
+The standard behavior for statuses like `NO_APPROOV_SERVICE` is to proceed with the request without adding an Approov token. This might occur, for example, if a device cannot connect to the Approov cloud due to a restricted network environment. You may wish to prevent this behavior to ensure that *only* requests with valid proof of attestation reach your backend API, allowing you to explicitly handle this case within your application.
+
+You can use a mutator to enforce this policy by throwing an error or returning `false` for such statuses.
+
+### Example: Enforce Token Presence
+
+Override `handleInterceptorFetchTokenResult` to check for `NO_APPROOV_SERVICE` and prevent the request to your API from continuing; instead log the event. Since `NO_APPROOV_SERVICE` implies the SDK cannot reach the Approov servers, this could be a transient issue (e.g., no DNS server available) or a permanent configuration/network restriction. You might choose to retry the request once to handle transient errors, or if the issue persists, inform the user of a network issue and suggest checking their connection or changing networks.
+
+```kotlin
+import io.approov.service.retrofit.ApproovServiceMutator
+import io.approov.service.retrofit.ApproovNetworkException
+import io.approov.service.retrofit.ApproovServiceMutator.DEFAULT
+import com.criticalblue.approovsdk.Approov
+
+class EnforceTokenMutator : ApproovServiceMutator {
+    override fun handleInterceptorFetchTokenResult(approovResults: Approov.TokenFetchResult, url: String): Boolean {
+        // If the service is not available (NO_APPROOV_SERVICE), do not proceed.
+        // This could be transient (e.g. no DNS) so we throw a networking error to trigger a retry.
+        if (approovResults.status == Approov.TokenFetchStatus.NO_APPROOV_SERVICE) {
+            throw ApproovNetworkException(approovResults.status, "Network issue. Will attempt connection again.")
+        }
+
+        // For all other statuses, use the default behavior.
+        return DEFAULT.handleInterceptorFetchTokenResult(approovResults, url)
+    }
+}
+```
+
+### Allow Access Without Token (Optional)
+
+Conversely, if the device could not obtain proof of attestation, for example because of a `POOR_NETWORK` or `NO_NETWORK` response from the SDK, the default behavior is to cancel the request to your API. However, you might prefer to let the request attempt the connection to your backend without the Approov Token to allow for server-side handling (e.g., returning a custom 401/403).
+
+To implement this, check for `POOR_NETWORK` and return `false`, which proceeds without the token validation (skips adding token).
+
+```kotlin
+    if (approovResults.status == Approov.TokenFetchStatus.POOR_NETWORK) {
+        return false // Proceed without token
+    }
+```
+
+
+### Add custom headers using a mutator
+
+You can override `handleInterceptorProcessedRequest` to add additional headers or modify the request after Approov has processed it. This is useful for adding app metadata or other diagnostics.
+
+```kotlin
+import okhttp3.Request
+import io.approov.service.retrofit.ApproovRequestMutations
+
+class MyMutator : ApproovServiceMutator {
+    // If you are composing with another mutator (like a signer), initialize it here.
+    // Otherwise, you can use ApproovServiceMutator.DEFAULT.
+    val signer: ApproovServiceMutator = ApproovServiceMutator.DEFAULT
+
+    /// Called after Approov has already mutated the request (token, substitutions, signing).
+    ///
+    /// Use this to add *additional* headers or rewrite the request further. This is also
+    /// where message signing should remain in place if you use a signer mutator.
+    override fun handleInterceptorProcessedRequest(request: Request,
+                                           changes: ApproovRequestMutations): Request {
+        val req = signer.handleInterceptorProcessedRequest(request, changes)
+        // Example: attach app metadata for backend diagnostics or routing.
+        return req.newBuilder()
+            .addHeader("Client-Platform", "android")
+            .build()
+    }
+}
+```
+
+## How to use a custom mutator in your application
+
+Create a mutator, then install it once during app startup (for example in your Application class or initialization path).
+
+```kotlin
+import io.approov.service.retrofit.ApproovService
+import io.approov.service.retrofit.ApproovServiceMutator
+
+class MyMutator : ApproovServiceMutator {
+    // Override only the hooks you need.
+}
+ApproovService.setServiceMutator(MyMutator()) // Install custom implementation or pass null to revert to default behaviour
+```
+
+## Approov Token Fallback Status
+
+If the SDK cannot obtain a valid Approov token (e.g., due to a `NO_NETWORK` or `MITM_DETECTED` state), the request traditionally proceeds without the `Approov-Token` header or fails entirely depending on the current policy. To give your backend visibility into *why* there is no token, you can use `ApproovService.setUseApproovStatusIfNoToken(true)`.
+
+When enabled, the service will inject the Approov fetch status directly into the `Approov-Token` header if the actual token fetch fails or is empty. Your backend can then distinguish between a request that was sent without a token due to an attacker stripping it, versus a legitimate request that encountered a specific failure like `POOR_NETWORK`. 
+
+Please note that this behavior is conditional upon the configuration of your `ApproovServiceMutator`. If your mutator explicitly throws an error or aborts the request entirely for a particular status (for example, throwing an exception on `NO_NETWORK`), the request will never proceed to the server, and this status fallback feature will effectively not be used for that specific case.
+
+## Message signing
+
+It is possible to sign HTTP requests using Approov to ensure message integrity and authenticity. There are two types of message signing available:
+
+1.  [Installation Message Signing](https://ext.approov.io/docs/latest/approov-usage-documentation/#installation-message-signing): Uses an installation-specific key (held in the device's Secure Enclave/TEE) to sign requests. This provides strong non-repudiation as the signing key never leaves the device and is unique to that specific installation.
+2.  [Account Message Signing](https://ext.approov.io/docs/latest/approov-usage-documentation/#account-message-signing): Uses a shared account-specific secret key (HMAC-SHA256) to sign requests. This key is delivered to the SDK only upon successful attestation.
+
+**Advantages of Message Signing:**
+*   **Integrity:** Ensures that the request parameters (headers, body, URL) have not been tampered with during transit.
+*   **Authenticity:** Proves that the request originated from a genuine, attested application instance.
+
+Message signing is not enabled unless you opt in. By default, the `ApproovService` uses the interface `ApproovServiceMutator` default, which does no message signing. Even if you install `ApproovDefaultMessageSigning`, a signature is only added when:
+
+- The request already has an `Approov-Token` header (i.e., Approov processing ran).
+- A `SignatureParametersFactory` is configured (default or host-specific).
+
+### Enable with default settings
+
+```kotlin
+import io.approov.service.retrofit.ApproovDefaultMessageSigning
+import io.approov.service.retrofit.ApproovService
+
+val factory = ApproovDefaultMessageSigning.generateDefaultSignatureParametersFactory()
+val signer = ApproovDefaultMessageSigning().setDefaultFactory(factory)
+ApproovService.setServiceMutator(signer)
+```
+
+If you have already customized the mutator, you can add message signing to it by composing or delegating.
+
+### Customize behavior
+
+```kotlin
+import io.approov.service.retrofit.ApproovDefaultMessageSigning.SignatureParametersFactory
+
+val factory = SignatureParametersFactory()
+    .setUseAccountMessageSigning() // or setUseInstallMessageSigning()
+    .setAddCreated(true)
+    .setExpiresLifetime(60)
+
+val signer = ApproovDefaultMessageSigning()
+    .setDefaultFactory(factory)
+    .putHostFactory("api.example.com", factory)
+
+ApproovService.setServiceMutator(signer)
+```
+
+To disable signing, remove the signer (`setServiceMutator(null)`) or return `null` from your factory for hosts you want to skip.
+
+## Token Binding
+
+[Token Binding](https://ext.approov.io/docs/latest/approov-usage-documentation/#token-binding) allows you to bind the Approov token to a specific piece of data, such as an OAuth token or a user session identifier. This adds an extra layer of security by ensuring that the Approov token can only be used in conjunction with the bound data. The `ApproovService` calculates a hash of the binding data locally and includes this hash in the Approov token claims. It is important to note that the actual binding data is never sent to the Approov cloud service; only the hash is transmitted.
+
+To set up token binding, you specify a header name. The value of this header in your requests will be used for the binding.
+
+### Example: Bind to Authorization Header
+
+```kotlin
+// Bind the Approov token to the Authorization header (e.g., for OAuth)
+ApproovService.setBindingHeader("Authorization")
+```
+
+If the value of the binding header changes (e.g., the user logs in and gets a new OAuth token), the SDK automatically invalidates the current Approov token and fetches a new one with the updated binding on the next request.
+
+## Real-world examples
+
+### Policy-driven mutator (host scoping, offline fallback, message signing, pinning)
+
+This example implementation demonstrates how to customize the `ApproovServiceMutator` to apply different options to API requests based on the hostname.
+
+```kotlin
+import okhttp3.Request
+import io.approov.service.retrofit.*
+import com.criticalblue.approovsdk.Approov
+
+class CustomLogic(
+    private val signer: ApproovServiceMutator = ApproovDefaultMessageSigning(),
+    private val protectedHosts: Set<String> = setOf("api.example.com"),
+    private val allowOfflineForHosts: Set<String> = setOf("status.example.com"),
+    private val skipPinningHosts: Set<String> = setOf("metrics.example.com")
+) : ApproovServiceMutator {
+
+    override fun handleInterceptorShouldProcessRequest(request: Request): Boolean {
+        val host = request.url.host
+        if (!protectedHosts.contains(host)) return false
+        return ApproovServiceMutator.DEFAULT.handleInterceptorShouldProcessRequest(request)
+    }
+
+    override fun handleInterceptorFetchTokenResult(approovResults: Approov.TokenFetchResult,
+                                           url: String): Boolean {
+        val host = java.net.URI(url).host
+        if ((approovResults.status == Approov.TokenFetchStatus.NO_NETWORK || 
+             approovResults.status == Approov.TokenFetchStatus.POOR_NETWORK) &&
+           allowOfflineForHosts.contains(host)) {
+            return false
+        }
+        return ApproovServiceMutator.DEFAULT.handleInterceptorFetchTokenResult(approovResults, url)
+    }
+
+    override fun handleInterceptorProcessedRequest(request: Request,
+                                           changes: ApproovRequestMutations): Request {
+        val req = signer.handleInterceptorProcessedRequest(request, changes)
+        return req.newBuilder()
+            .addHeader("X-Client-Platform", "android")
+            .build()
+    }
+
+    override fun handlePinningShouldProcessRequest(request: Request): Boolean {
+        val host = request.url.host
+        if (skipPinningHosts.contains(host)) return false
+        return true
+    }
+}
+```
+
+### Log rejections with ARC + device ID to your telemetry
+
+An important part of your security strategy is to monitor and analyze rejections. Ideally, the server response would be customized to include the ARC and device ID in the response body or headers. However, if this is not possible, you can obtain these values from the `ApproovService` and log them to your telemetry directly from your application code.
+
+This example shows how to log rejections with the ARC and device ID. 
+
+```kotlin
+        val response = client.newCall(request).execute()
+        if (response.isSuccessful) {
+            // Process request
+        } else {
+            // Log rejection: ARC + device ID can be added for correlating a particular request to the failure reason
+            val arc = ApproovService.getLastARC() 
+            val deviceID = ApproovService.getDeviceID()
+            // Log rejection
+            Log.d("StartFragment", "Request rejected with ARC: $arc and device ID: $deviceID; response code: ${response.code}")
+        }
+```
+
+## Tips
+
+- Keep mutator logic fast and side-effect safe. These hooks run on the request path.
+- Use `ApproovServiceMutator.DEFAULT` to preserve the existing behavior and layer your changes on top.
+- If you override multiple hooks, keep them focused (one concern per hook) for easier testing and maintenance.

--- a/approov-service/build.gradle
+++ b/approov-service/build.gradle
@@ -26,6 +26,12 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
+    testOptions {
+        unitTests.returnDefaultValues = true
+        unitTests.all {
+            jvmArgs '-Dnet.bytebuddy.experimental=true'
+        }
+    }
 }
 
 dependencies {
@@ -36,4 +42,5 @@ dependencies {
     implementation 'com.squareup.retrofit2:converter-gson:2.11.0'
     implementation 'androidx.annotation:annotation-jvm:1.9.1'
     testImplementation 'junit:junit:4.13.2'
+    testImplementation 'org.mockito:mockito-inline:5.2.0'
 }

--- a/approov-service/pom.xml
+++ b/approov-service/pom.xml
@@ -39,7 +39,7 @@
     </dependency>
     <dependency>
       <groupId>org.bouncycastle</groupId>
-      <artifactId>bcprov-jdk18on</artifactId>
+      <artifactId>bcprov-jdk15to18</artifactId>
       <version>1.80</version>
       <scope>runtime</scope>
     </dependency>
@@ -52,13 +52,19 @@
     <dependency>
         <groupId>com.squareup.retrofit2</groupId>
         <artifactId>retrofit</artifactId>
-        <version>2.9.0</version>
+        <version>2.11.0</version>
         <scope>runtime</scope>
     </dependency>
     <dependency>
         <groupId>com.squareup.retrofit2</groupId>
         <artifactId>converter-gson</artifactId>
-        <version>2.9.0</version>
+        <version>2.11.0</version>
+        <scope>runtime</scope>
+    </dependency>
+    <dependency>
+        <groupId>androidx.annotation</groupId>
+        <artifactId>annotation-jvm</artifactId>
+        <version>1.9.1</version>
         <scope>runtime</scope>
     </dependency>
 </dependencies>

--- a/approov-service/src/main/java/io/approov/service/retrofit/ApproovDefaultMessageSigning.java
+++ b/approov-service/src/main/java/io/approov/service/retrofit/ApproovDefaultMessageSigning.java
@@ -136,6 +136,38 @@ public class ApproovDefaultMessageSigning implements ApproovInterceptorExtension
     }
 
     /**
+     * Retrieves an install message signature for the supplied message.
+     *
+     * @param message The message to be signed.
+     * @return The base64-encoded ASN.1 DER signature.
+     * @throws ApproovException If signing is unavailable.
+     */
+    protected String getInstallMessageSignature(String message) throws ApproovException {
+        return ApproovService.getInstallMessageSignature(message);
+    }
+
+    /**
+     * Retrieves an account message signature for the supplied message.
+     *
+     * @param message The message to be signed.
+     * @return The base64-encoded signature.
+     * @throws ApproovException If signing is unavailable.
+     */
+    protected String getAccountMessageSignature(String message) throws ApproovException {
+        return ApproovService.getAccountMessageSignature(message);
+    }
+
+    /**
+     * Decodes a base64-encoded signature value.
+     *
+     * @param base64 The signature bytes encoded as base64.
+     * @return The decoded bytes.
+     */
+    protected byte[] decodeBase64(String base64) {
+        return Base64.decode(base64, Base64.NO_WRAP);
+    }
+
+    /**
      * Converts one part, encoded as an ASN1Integer, of an ASN.1 DER encoded ES256 signature to a byte array of
      * exactly 32 bytes. Throws IllegalArgumentException if this is not possible.
      *
@@ -199,7 +231,7 @@ public class ApproovDefaultMessageSigning implements ApproovInterceptorExtension
                 sigId = "install";
                 String base64;
                 try {
-                    base64 = ApproovService.getInstallMessageSignature(message);
+                    base64 = getInstallMessageSignature(message);
                 } catch (ApproovException e) {
                     Log.d(TAG, "Failed to get InstallMessageSignature - skipping message signing " + e);
                     return request;
@@ -208,7 +240,7 @@ public class ApproovDefaultMessageSigning implements ApproovInterceptorExtension
                     Log.d(TAG, "InstallMessageSignature is empty - skipping message signing");
                     return request;
                 }
-                signature = Base64.decode(base64, Base64.NO_WRAP);
+                signature = decodeBase64(base64);
                 // decode the signature from ASN.1 DER format
                 try (ASN1InputStream asn1InputStream = new ASN1InputStream(signature)) {
                     ASN1Sequence sequence = (ASN1Sequence) asn1InputStream.readObject();
@@ -229,8 +261,8 @@ public class ApproovDefaultMessageSigning implements ApproovInterceptorExtension
             }
             case ALG_HS256: {
                 sigId = "account";
-                String base64 = ApproovService.getAccountMessageSignature(message);
-                signature = Base64.decode(base64, Base64.NO_WRAP);
+                String base64 = getAccountMessageSignature(message);
+                signature = decodeBase64(base64);
                 break;
             }
             default:
@@ -252,8 +284,11 @@ public class ApproovDefaultMessageSigning implements ApproovInterceptorExtension
         // Update the request from the one held by the component provider as the signature builder
         // may have modified it.
         Request.Builder signedBuilder = provider.getRequest().newBuilder()
-                .addHeader("Signature", sigHeader)
-                .addHeader("Signature-Input", sigInputHeader);
+                .removeHeader("Signature")
+                .removeHeader("Signature-Input")
+                .removeHeader("Signature-Base-Digest")
+                .header("Signature", sigHeader)
+                .header("Signature-Input", sigInputHeader);
         if (params.isDebugMode()) {
             try {
                 MessageDigest digestBuilder = MessageDigest.getInstance("SHA-256");
@@ -261,7 +296,7 @@ public class ApproovDefaultMessageSigning implements ApproovInterceptorExtension
                 byte[] digest = digestBuilder.digest(message.getBytes(StandardCharsets.UTF_8));
                 String digestHeader = Dictionary.valueOf(Map.of(
                         DIGEST_SHA256, ByteSequenceItem.valueOf(digest))).serialize();
-                signedBuilder.addHeader("Signature-Base-Digest", digestHeader);
+                signedBuilder.header("Signature-Base-Digest", digestHeader);
             } catch (NoSuchAlgorithmException e) {
                 Log.d(TAG, "Failed to get digest algorithm - no debug entry " + e);
             }
@@ -500,7 +535,7 @@ public class ApproovDefaultMessageSigning implements ApproovInterceptorExtension
             // add the digest to the request
             Request request = provider.getRequest();
             request = request.newBuilder()
-                    .addHeader("Content-Digest", digestHeader.serialize())
+                    .header("Content-Digest", digestHeader.serialize())
                     .build();
             provider.setRequest(request);
             // add the header to the SignatureParameters

--- a/approov-service/src/main/java/io/approov/service/retrofit/ApproovDefaultMessageSigning.java
+++ b/approov-service/src/main/java/io/approov/service/retrofit/ApproovDefaultMessageSigning.java
@@ -197,7 +197,17 @@ public class ApproovDefaultMessageSigning implements ApproovInterceptorExtension
         switch (params.getAlg()) {
             case ALG_ES256: {
                 sigId = "install";
-                String base64 = ApproovService.getInstallMessageSignature(message);
+                String base64;
+                try {
+                    base64 = ApproovService.getInstallMessageSignature(message);
+                } catch (ApproovException e) {
+                    Log.d(TAG, "Failed to get InstallMessageSignature - skipping message signing " + e);
+                    return request;
+                }
+                if (base64.isEmpty()) {
+                    Log.d(TAG, "InstallMessageSignature is empty - skipping message signing");
+                    return request;
+                }
                 signature = Base64.decode(base64, Base64.NO_WRAP);
                 // decode the signature from ASN.1 DER format
                 try (ASN1InputStream asn1InputStream = new ASN1InputStream(signature)) {

--- a/approov-service/src/main/java/io/approov/service/retrofit/ApproovFetchStatusException.java
+++ b/approov-service/src/main/java/io/approov/service/retrofit/ApproovFetchStatusException.java
@@ -20,28 +20,29 @@ package io.approov.service.retrofit;
 import com.criticalblue.approovsdk.Approov;
 
 /**
- * @deprecated Use {@link ApproovFetchStatusException} instead. This subtype is retained only to avoid
- *             breaking existing handlers and call sites; migrate any explicit catches to use the parent class.
+ * Exception raised when an Approov token fetch returns a status other than success.
  */
-@Deprecated
-public class ApproovNetworkException extends ApproovFetchStatusException {
+public class ApproovFetchStatusException extends ApproovException {
+
+    private final Approov.TokenFetchStatus tokenFetchStatus;
 
     /**
-     * Constructs an Approov networking exception.
+     * Constructs a token fetch status exception with the provided status.
      *
-     * @param message basic information about the exception cause
+     * @param status status returned by the Approov SDK, may be {@code null} if unavailable
+     * @param message information describing the exception cause
      */
-    public ApproovNetworkException(String message) {
-        super(null, message);
+    public ApproovFetchStatusException(Approov.TokenFetchStatus status, String message) {
+        super(message);
+        this.tokenFetchStatus = status;
     }
 
     /**
-     * Constructs an Approov networking exception with a specific token fetch status.
+     * Retrieves the token fetch status associated with this exception.
      *
-     * @param status token fetch status that triggered the error
-     * @param message basic information about the exception cause
+     * @return the status returned by the Approov SDK, or {@code null} if not provided
      */
-    public ApproovNetworkException(Approov.TokenFetchStatus status, String message) {
-        super(status, message);
+    public Approov.TokenFetchStatus getTokenFetchStatus() {
+        return tokenFetchStatus;
     }
 }

--- a/approov-service/src/main/java/io/approov/service/retrofit/ApproovInterceptorExtensions.java
+++ b/approov-service/src/main/java/io/approov/service/retrofit/ApproovInterceptorExtensions.java
@@ -23,16 +23,34 @@ import okhttp3.Request;
  * ApproovInterceptorExtensions provides an interface for handling callbacks during
  * the processing of network requests by Approov. It allows further modifications
  * to requests after Approov has applied its changes.
+ *
+ * @deprecated Replace implementations of this interface with ApproovServiceMutator
+ * while changing the name of the ApproovInterceptorExtensions.processedRequest
+ * method to ApproovServiceMutator.handleInterceptorProcessedRequest.
  */
-public interface ApproovInterceptorExtensions {
+@Deprecated
+public interface ApproovInterceptorExtensions extends ApproovServiceMutator{
 
     /**
-     * Called after Approov has processed a network request, allowing further modifications.
+     * Replace the default implementation of ApproovServiceMutator.handleInterceptorProcessedRequest
+     * to call the now deprecated ApproovInterceptorExtensions.processedRequest method. 
      *
      * @param request the processed request
      * @param changes the mutations applied to the request by Approov
-     * @return the modified request
+     * @return the final request to use to complete the Approov interceptor step.
      * @throws ApproovException if there is an error during processing
      */
-    Request processedRequest(Request request, ApproovRequestMutations changes) throws ApproovException;
+    default Request handleInterceptorProcessedRequest(Request request, ApproovRequestMutations changes) throws ApproovException {
+        // call the deprecated method to maintain backwards compatibility
+        return processedRequest(request, changes);
+    }
+
+    /**
+     * @deprecated Use ApproovServiceMutator.handleInterceptorProcessedRequest instead.
+     */
+    @Deprecated
+    default Request processedRequest(Request request, ApproovRequestMutations changes) throws ApproovException {
+        // No further changes to the request are required
+        return request;
+    }
 }

--- a/approov-service/src/main/java/io/approov/service/retrofit/ApproovRejectionException.java
+++ b/approov-service/src/main/java/io/approov/service/retrofit/ApproovRejectionException.java
@@ -1,6 +1,6 @@
 //
 // MIT License
-// 
+//
 // Copyright (c) 2016-present, Approov Ltd.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files
@@ -9,7 +9,7 @@
 // subject to the following conditions:
 //
 // The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR
 // ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH
@@ -17,23 +17,23 @@
 
 package io.approov.service.retrofit;
 
-// ApproovRejectionException provides additional information if the app has been rejected by Approov
-public class ApproovRejectionException extends ApproovException {
-    // provides a code of the app state for support purposes
-    private String arc;
+import com.criticalblue.approovsdk.Approov;
 
+public class ApproovRejectionException extends ApproovFetchStatusException {
+    // provides a code of the app state for support purposes
+    private final String arc;
     // provides a comma separated list of rejection reasons (if the feature is enabled in Approov)
-    private String rejectionReasons;
+    private final String rejectionReasons;
 
     /**
      * Constructs an exception if the app is rejected by Approov.
      *
-     * @param message is the basic information about the exception cause
-     * @param arc is the code that can be used for support purposes
-     * @param rejectionReasons may provide a comma separated list of rejection reasons
+     * @param message basic information about the exception cause
+     * @param arc code that can be used for support purposes
+     * @param rejectionReasons comma separated list of rejection reasons, may be {@code null}
      */
     public ApproovRejectionException(String message, String arc, String rejectionReasons) {
-        super(message);
+        super(Approov.TokenFetchStatus.REJECTED, message);
         this.arc = arc;
         this.rejectionReasons = rejectionReasons;
     }

--- a/approov-service/src/main/java/io/approov/service/retrofit/ApproovService.java
+++ b/approov-service/src/main/java/io/approov/service/retrofit/ApproovService.java
@@ -29,6 +29,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -75,6 +76,10 @@ public class ApproovService {
     // Approov token
     private static boolean proceedOnNetworkFail = false;
 
+    // true if the Approov fetch status should be used as the token header value if the
+    // actual token fetch fails or returns an empty token
+    private static boolean useApproovStatusIfNoToken = false;
+
     // the Approov pinning interceptor to be used for all requests
     private static ApproovPinningInterceptor pinningInterceptor = null;
 
@@ -93,11 +98,10 @@ public class ApproovService {
     // any header to be used for binding in Approov tokens or null if not set
     private static String bindingHeader = null;
 
-    // An optional property to receive callbacks during the processing of a request. Added to
-    // support message signing in a general way, the callbacks give an opportunity for apps to
-    // customise behaviour at specific points in the attestation flow.
-    // Defaults to null - no callback.
-    private static ApproovInterceptorExtensions interceptorExtensions = null;
+    // The mutator instance used to control ApproovService behavior at key points in the flow.
+    // Unless set using the ApproovService.setServiceMutator() method, the default behaviour 
+    // defined in the default implementation of ApproovServiceMutator will be used.
+    private static ApproovServiceMutator serviceMutator = ApproovServiceMutator.DEFAULT;
 
     // map of headers that should have their values substituted for secure strings, mapped to their
     // required prefixes
@@ -137,12 +141,14 @@ public class ApproovService {
             // setup ready for building Retrofit instances
             isInitialized = false;
             proceedOnNetworkFail = false;
+            useApproovStatusIfNoToken = false;
             okHttpBuilder = new OkHttpClient.Builder();
             retrofitMap = new HashMap<>();
             approovTokenHeader = APPROOV_TOKEN_HEADER;
             approovTokenPrefix = APPROOV_TOKEN_PREFIX;
             approovTraceIDHeader = APPROOV_TRACE_ID_HEADER;
             bindingHeader = null;
+            serviceMutator = ApproovServiceMutator.DEFAULT;
             substitutionHeaders = new HashMap<>();
             substitutionQueryParams = new HashMap<>();
             exclusionURLRegexs = new HashMap<>();
@@ -185,7 +191,9 @@ public class ApproovService {
      * channel to a MitM.
      *
      * @param proceed is true if Approov networking fails should allow continuation
+     * @deprecated Use setServiceMutator to control this behavior
      */
+    @Deprecated
     public static synchronized void setProceedOnNetworkFail(boolean proceed) {
         Log.d(TAG, "setProceedOnNetworkFail " + proceed);
         proceedOnNetworkFail = proceed;
@@ -196,9 +204,37 @@ public class ApproovService {
      * not possible to obtain an Approov token due to a networking failure.
      *
      * @return true if Approov networking fails should allow continuation, false otherwise
+     * @deprecated Use setServiceMutator to control this behavior
      */
+    @Deprecated
     public static synchronized boolean getProceedOnNetworkFail() {
         return proceedOnNetworkFail;
+    }
+
+    /**
+     * Sets a flag indicating if the Approov fetch status (e.g. "NO_NETWORK",
+     * "MITM_DETECTED")
+     * should be used as the token header value if the actual token fetch fails or
+     * returns an empty token.
+     * This allows passing error condition information to the backend via the
+     * Approov-Token header,
+     * which might otherwise be empty or missing.
+     *
+     * @param shouldUse is true if the status should be used as the token value
+     */
+    public static synchronized void setUseApproovStatusIfNoToken(boolean shouldUse) {
+        Log.d(TAG, "setUseApproovStatusIfNoToken " + shouldUse);
+        useApproovStatusIfNoToken = shouldUse;
+    }
+
+    /**
+     * Gets a flag indicating if the Approov fetch status should be used as the token header value
+     * if the actual token fetch fails or returns an empty token.
+     *
+     * @return true if the status should be used as the token value, false otherwise
+     */
+    public static synchronized boolean getUseApproovStatusIfNoToken() {
+        return useApproovStatusIfNoToken;
     }
 
     /**
@@ -304,31 +340,53 @@ public class ApproovService {
     }
 
     /**
-     * Sets the interceptor extensions callback handler. This facility was introduced to support
-     * message signing that is independent from the rest of the attestation flow. The default
-     * ApproovService layer issues no callbacks, provide a non-null ApproovInterceptorExtensions
-     * handler to add functionality to the attestation flow.
+     * Sets the ApproovServiceMutator instance to handle callbacks from the
+     * ApproovService implementation. This facility enables customization of
+     * ApproovService operations at key points in the configuration and
+     * attestation flows. It should reduce the number of times this service
+     * layer implementation needs to be forked in order to introduce custom
+     * behavior.
      *
-     * @param callbacks is the configuration used to control message signing. The behaviour of the
-     *              provided configuration must remain constant while in use by the ApproovService.
-     *              Passing null to this method will disable message signing.
+     * @param mutator is the ApproovServiceMutator with callback handlers that may
+     *                override the default behavior of the ApproovService singleton.
+     *                Passing null to this method will reinstate the default
+     *                behavior.
      */
-    public static synchronized void setApproovInterceptorExtensions(ApproovInterceptorExtensions callbacks) {
-        if (callbacks == null) {
-            Log.d(TAG, "Interceptor extension disabled");
-        } else {
-            Log.d(TAG, "Interceptor extension enabled");
+    public static synchronized void setServiceMutator(ApproovServiceMutator mutator) {
+        if (mutator == null) {
+            mutator = ApproovServiceMutator.DEFAULT;
         }
-        interceptorExtensions = callbacks;
+        Log.d(TAG, "Applied ApproovServiceMutator:" + mutator.toString());
+        serviceMutator = mutator;
+    }
+
+    /**
+     * @deprecated Use setServiceMutator instead
+     */
+    @Deprecated
+    public static void setApproovInterceptorExtensions(ApproovServiceMutator mutator) {
+        setServiceMutator(mutator);
+    }
+
+    /**
+     * Gets the active service mutator instance that is handling callbacks from
+     * ApproovService.
+     *
+     * @return the service mutator instance (never null)
+     */
+    public static synchronized ApproovServiceMutator getServiceMutator() {
+        return serviceMutator;
     }
 
     /**
      * Gets the interceptor extensions callback handlers.
      *
      * @return the interceptor extensions callback handlers or null if none set
+     * @deprecated Use getServiceMutator instead
      */
-    public static synchronized ApproovInterceptorExtensions getApproovInterceptorExtensions() {
-        return interceptorExtensions;
+    @Deprecated
+    public static ApproovServiceMutator getApproovInterceptorExtensions() {
+        return getServiceMutator();
     }
 
     /**
@@ -501,22 +559,8 @@ public class ApproovService {
             throw new ApproovException("IllegalArgument: " + e.getMessage());
         }
 
-        // process the returned Approov status
-        if (approovResults.getStatus() == Approov.TokenFetchStatus.REJECTED)
-            // if the request is rejected then we provide a special exception with additional information
-            throw new ApproovRejectionException("precheck: " + approovResults.getStatus().toString() + ": " +
-                    approovResults.getARC() + " " + approovResults.getRejectionReasons(),
-                    approovResults.getARC(), approovResults.getRejectionReasons());
-        else if ((approovResults.getStatus() == Approov.TokenFetchStatus.NO_NETWORK) ||
-                (approovResults.getStatus() == Approov.TokenFetchStatus.POOR_NETWORK) ||
-                (approovResults.getStatus() == Approov.TokenFetchStatus.MITM_DETECTED))
-            // we are unable to get the secure string due to network conditions so the request can
-            // be retried by the user later
-            throw new ApproovNetworkException("precheck: " + approovResults.getStatus().toString());
-        else if ((approovResults.getStatus() != Approov.TokenFetchStatus.SUCCESS) &&
-                (approovResults.getStatus() != Approov.TokenFetchStatus.UNKNOWN_KEY))
-            // we are unable to get the secure string due to a more permanent error
-            throw new ApproovException("precheck:" + approovResults.getStatus().toString());
+        // process the returned Approov status using decision maker
+        getServiceMutator().handlePrecheckResult(approovResults);
     }
 
     /**
@@ -588,18 +632,9 @@ public class ApproovService {
             throw new ApproovException("IllegalArgument: " + e.getMessage());
         }
 
-        // process the status
-        if ((approovResults.getStatus() == Approov.TokenFetchStatus.NO_NETWORK) ||
-                (approovResults.getStatus() == Approov.TokenFetchStatus.POOR_NETWORK) ||
-                (approovResults.getStatus() == Approov.TokenFetchStatus.MITM_DETECTED))
-            // we are unable to get the token due to network conditions
-            throw new ApproovNetworkException("fetchToken: " + approovResults.getStatus().toString());
-        else if (approovResults.getStatus() != Approov.TokenFetchStatus.SUCCESS)
-            // we are unable to get the token due to a more permanent error
-            throw new ApproovException("fetchToken: " + approovResults.getStatus().toString());
-        else
-            // provide the Approov token result
-            return approovResults.getToken();
+        // process the status using decision maker
+        getServiceMutator().handleFetchTokenResult(approovResults);
+        return approovResults.getToken();
     }
 
     /**
@@ -719,25 +754,8 @@ public class ApproovService {
             throw new ApproovException("IllegalArgument: " + e.getMessage());
         }
 
-        // process the returned Approov status
-        if (approovResults.getStatus() == Approov.TokenFetchStatus.REJECTED)
-            // if the request is rejected then we provide a special exception with additional information
-            throw new ApproovRejectionException("fetchSecureString " + type + " for " + key + ": " +
-                    approovResults.getStatus().toString() + ": " + approovResults.getARC() +
-                    " " + approovResults.getRejectionReasons(),
-                    approovResults.getARC(), approovResults.getRejectionReasons());
-        else if ((approovResults.getStatus() == Approov.TokenFetchStatus.NO_NETWORK) ||
-                (approovResults.getStatus() == Approov.TokenFetchStatus.POOR_NETWORK) ||
-                (approovResults.getStatus() == Approov.TokenFetchStatus.MITM_DETECTED))
-            // we are unable to get the secure string due to network conditions so the request can
-            // be retried by the user later
-            throw new ApproovNetworkException("fetchSecureString " + type + " for " + key + ":" +
-                    approovResults.getStatus().toString());
-        else if ((approovResults.getStatus() != Approov.TokenFetchStatus.SUCCESS) &&
-                (approovResults.getStatus() != Approov.TokenFetchStatus.UNKNOWN_KEY))
-            // we are unable to get the secure string due to a more permanent error
-            throw new ApproovException("fetchSecureString " + type + " for " + key + ":" +
-                    approovResults.getStatus().toString());
+        // process the returned Approov status using decision maker
+        getServiceMutator().handleFetchSecureStringResult(approovResults, type, key);
         return approovResults.getSecureString();
     }
 
@@ -766,21 +784,8 @@ public class ApproovService {
             throw new ApproovException("IllegalArgument: " + e.getMessage());
         }
 
-        // process the returned Approov status
-        if (approovResults.getStatus() == Approov.TokenFetchStatus.REJECTED)
-            // if the request is rejected then we provide a special exception with additional information
-            throw new ApproovRejectionException("fetchCustomJWT: "+ approovResults.getStatus().toString() + ": " +
-                    approovResults.getARC() +  " " + approovResults.getRejectionReasons(),
-                    approovResults.getARC(), approovResults.getRejectionReasons());
-        else if ((approovResults.getStatus() == Approov.TokenFetchStatus.NO_NETWORK) ||
-                (approovResults.getStatus() == Approov.TokenFetchStatus.POOR_NETWORK) ||
-                (approovResults.getStatus() == Approov.TokenFetchStatus.MITM_DETECTED))
-            // we are unable to get the custom JWT due to network conditions so the request can
-            // be retried by the user later
-            throw new ApproovNetworkException("fetchCustomJWT: " + approovResults.getStatus().toString());
-        else if (approovResults.getStatus() != Approov.TokenFetchStatus.SUCCESS)
-            // we are unable to get the custom JWT due to a more permanent error
-            throw new ApproovException("fetchCustomJWT: " + approovResults.getStatus().toString());
+        // process the returned Approov status using decision maker
+        getServiceMutator().handleFetchCustomJWTResult(approovResults);
         return approovResults.getToken();
     }
 
@@ -964,16 +969,15 @@ class ApproovTokenInterceptor implements Interceptor {
 
     @Override
     public Response intercept(Chain chain) throws IOException {
-        // The mutator object is used to record any changes we need to make to the request
-        ApproovRequestMutations changes = new ApproovRequestMutations();
+
         Request request = chain.request();
-        String url = request.url().toString();
-        // check if the URL matches one of the exclusion regexs and just proceed if so
-        for (Pattern pattern: ApproovService.getExclusionURLRegexs().values()) {
-            Matcher matcher = pattern.matcher(url);
-            if (matcher.find()) {
-                return chain.proceed(request);
-            }
+        // cache the mutator for the duration of the interceptor to make sure
+        // it is not changed mid-flight
+        ApproovServiceMutator mutator = ApproovService.getServiceMutator();
+        // first check if we are to proceed with any Approov processing
+        if (!mutator.handleInterceptorShouldProcessRequest(request)) {
+            // we are not to proceed with any Approov processing so just continue
+            return chain.proceed(request);
         }
 
         // update the data hash based on any token binding header (presence is optional)
@@ -981,13 +985,15 @@ class ApproovTokenInterceptor implements Interceptor {
         if ((bindingHeader != null) && request.headers().names().contains(bindingHeader))
             Approov.setDataHashInToken(request.header(bindingHeader));
 
+        okhttp3.HttpUrl url = request.url();
+
         // request an Approov token for the request URL
-        Approov.TokenFetchResult approovResults = Approov.fetchApproovTokenAndWait(url);
+        Approov.TokenFetchResult approovResults = Approov.fetchApproovTokenAndWait(url.toString());
 
         // provide information about the obtained token or error (note "approov token -check" can
         // be used to check the validity of the token and if you use token annotations they
         // will appear here to determine why a request is being rejected)
-        Log.d(TAG, "Token for " + url + ": " + approovResults.getLoggableToken());
+        Log.d(TAG, "Token for " + url.toString() + ": " + approovResults.getLoggableToken());
 
         // force a pinning rebuild if there is any dynamic config update
         if (approovResults.isConfigChanged()) {
@@ -996,79 +1002,50 @@ class ApproovTokenInterceptor implements Interceptor {
             Log.d(TAG, "Dynamic configuration updated");
         }
 
-        // check the status of Approov token fetch
+        // check the status of Approov token fetch using decision maker
         boolean aChange = false;
         String setTokenHeaderKey = null;
         String setTokenHeaderValue = null;
         String setTraceIDHeaderKey = null;
         String setTraceIDHeaderValue = null;
-        if (approovResults.getStatus() == Approov.TokenFetchStatus.SUCCESS) {
+        if (mutator.handleInterceptorFetchTokenResult(approovResults, url.toString())) {
             // we successfully obtained a token so add it to the header for the request
             aChange = true;
             setTokenHeaderKey = ApproovService.getApproovTokenHeader();
-            setTokenHeaderValue = ApproovService.getApproovTokenPrefix() + approovResults.getToken();
+            if ((approovResults.getToken().isEmpty()) && ApproovService.getUseApproovStatusIfNoToken())
+                setTokenHeaderValue = ApproovService.getApproovTokenPrefix() + approovResults.getStatus().toString();
+            else
+                setTokenHeaderValue = ApproovService.getApproovTokenPrefix() + approovResults.getToken();
+
             String traceIDHeader = ApproovService.getApproovTraceIDHeader();
             String traceID = approovResults.getTraceID();
             if ((traceIDHeader != null) && (traceID != null) && !traceID.isEmpty()) {
                 setTraceIDHeaderKey = traceIDHeader;
                 setTraceIDHeaderValue = traceID;
             }
-        } else if ((approovResults.getStatus() == Approov.TokenFetchStatus.NO_NETWORK) ||
-                 (approovResults.getStatus() == Approov.TokenFetchStatus.POOR_NETWORK) ||
-                 (approovResults.getStatus() == Approov.TokenFetchStatus.MITM_DETECTED)) {
-            // we are unable to get an Approov token due to network conditions so the request can
-            // be retried by the user later - unless this is overridden
-            if (!ApproovService.getProceedOnNetworkFail())
-                throw new ApproovNetworkException("Approov token fetch for " + url + ": " + approovResults.getStatus().toString());
-        }
-        else if ((approovResults.getStatus() != Approov.TokenFetchStatus.NO_APPROOV_SERVICE) &&
-                 (approovResults.getStatus() != Approov.TokenFetchStatus.UNKNOWN_URL) &&
-                 (approovResults.getStatus() != Approov.TokenFetchStatus.UNPROTECTED_URL))
-            // we have failed to get an Approov token with a more serious permanent error
-            throw new ApproovException("Approov token fetch for " + url + ": " + approovResults.getStatus().toString());
-
-        // we only continue additional processing if we had a valid status from Approov, to prevent additional delays
-        // by trying to fetch from Approov again and this also protects against header substitutions in domains not
-        // protected by Approov and therefore potential subject to a MitM
-        if ((approovResults.getStatus() != Approov.TokenFetchStatus.SUCCESS) &&
-                (approovResults.getStatus() != Approov.TokenFetchStatus.UNPROTECTED_URL))
+        } else {
+            // we only continue additional processing if we had a valid status from Approov, to prevent additional delays
+            // by trying to fetch from Approov again and this also protects against header substitutions in domains not
+            // protected by Approov and therefore potential subject to a MitM
             // setTokenHeaderKey and setTokenHeaderValue must be null
             return chain.proceed(request);
+        }
 
         // we now deal with any header substitutions, which may require further fetches but these
         // should be using cached results
         Map<String, String> substitutionHeaders = ApproovService.getSubstitutionHeaders();
-        Map<String,String> setSubstitutionHeaders = new LinkedHashMap<>(substitutionHeaders.size());
-        for (Map.Entry<String, String> entry: substitutionHeaders.entrySet()) {
+        Map<String, String> setSubstitutionHeaders = new java.util.LinkedHashMap<>(substitutionHeaders.size());
+        for (Map.Entry<String, String> entry : substitutionHeaders.entrySet()) {
             String header = entry.getKey();
             String prefix = entry.getValue();
             String value = request.header(header);
             if ((value != null) && value.startsWith(prefix) && (value.length() > prefix.length())) {
                 approovResults = Approov.fetchSecureStringAndWait(value.substring(prefix.length()), null);
                 Log.d(TAG, "Substituting header: " + header + ", " + approovResults.getStatus().toString());
-                if (approovResults.getStatus() == Approov.TokenFetchStatus.SUCCESS) {
+                if (mutator.handleInterceptorHeaderSubstitutionResult(approovResults, header)) {
                     aChange = true;
                     setSubstitutionHeaders.put(header, prefix + approovResults.getSecureString());
                 }
-                else if (approovResults.getStatus() == Approov.TokenFetchStatus.REJECTED)
-                    // if the request is rejected then we provide a special exception with additional information
-                    throw new ApproovRejectionException("Header substitution for " + header + ": " +
-                        approovResults.getStatus().toString() + ": " + approovResults.getARC() +
-                        " " + approovResults.getRejectionReasons(),
-                        approovResults.getARC(), approovResults.getRejectionReasons());
-                else if ((approovResults.getStatus() == Approov.TokenFetchStatus.NO_NETWORK) ||
-                        (approovResults.getStatus() == Approov.TokenFetchStatus.POOR_NETWORK) ||
-                        (approovResults.getStatus() == Approov.TokenFetchStatus.MITM_DETECTED)) {
-                    // we are unable to get the secure string due to network conditions so the request can
-                    // be retried by the user later - unless this is overridden
-                    if (!ApproovService.getProceedOnNetworkFail())
-                        throw new ApproovNetworkException("Header substitution for " + header + ": " +
-                            approovResults.getStatus().toString());
-                }
-                else if (approovResults.getStatus() != Approov.TokenFetchStatus.UNKNOWN_KEY)
-                    // we have failed to get a secure string with a more serious permanent error
-                    throw new ApproovException("Header substitution for " + header + ": " +
-                        approovResults.getStatus().toString());
             }
         }
 
@@ -1078,7 +1055,7 @@ class ApproovTokenInterceptor implements Interceptor {
         String replacementURL = originalURL;
         Map<String, Pattern> substitutionQueryParams = ApproovService.getSubstitutionQueryParams();
         List<String> queryKeys = new ArrayList<>(substitutionQueryParams.size());
-        for (Map.Entry<String, Pattern> entry: substitutionQueryParams.entrySet()) {
+        for (Map.Entry<String, Pattern> entry : substitutionQueryParams.entrySet()) {
             String queryKey = entry.getKey();
             Pattern pattern = entry.getValue();
             Matcher matcher = pattern.matcher(replacementURL);
@@ -1088,36 +1065,18 @@ class ApproovTokenInterceptor implements Interceptor {
                 String queryValue = matcher.group(1);
                 approovResults = Approov.fetchSecureStringAndWait(queryValue, null);
                 Log.d(TAG, "Substituting query parameter: " + queryKey + ", " + approovResults.getStatus().toString());
-
-                if (approovResults.getStatus() == Approov.TokenFetchStatus.SUCCESS) {
+                if (mutator.handleInterceptorQueryParamSubstitutionResult(approovResults, queryKey)) {
                     // substitute the query parameter
                     aChange = true;
                     queryKeys.add(queryKey);
                     replacementURL = new StringBuilder(replacementURL).replace(matcher.start(1),
                             matcher.end(1), approovResults.getSecureString()).toString();
                 }
-                else if (approovResults.getStatus() == Approov.TokenFetchStatus.REJECTED)
-                    // if the request is rejected then we provide a special exception with additional information
-                    throw new ApproovRejectionException("Query parameter substitution for " + queryKey + ": " +
-                            approovResults.getStatus().toString() + ": " + approovResults.getARC() +
-                            " " + approovResults.getRejectionReasons(),
-                            approovResults.getARC(), approovResults.getRejectionReasons());
-                else if ((approovResults.getStatus() == Approov.TokenFetchStatus.NO_NETWORK) ||
-                        (approovResults.getStatus() == Approov.TokenFetchStatus.POOR_NETWORK) ||
-                        (approovResults.getStatus() == Approov.TokenFetchStatus.MITM_DETECTED)) {
-                    // we are unable to get the secure string due to network conditions so the request can
-                    // be retried by the user later - unless this is overridden
-                    if (!ApproovService.getProceedOnNetworkFail())
-                        throw new ApproovNetworkException("Query parameter substitution for " + queryKey + ": " +
-                            approovResults.getStatus().toString());
-                }
-                else if (approovResults.getStatus() != Approov.TokenFetchStatus.UNKNOWN_KEY)
-                    // we have failed to get a secure string with a more serious permanent error
-                    throw new ApproovException("Query parameter substitution for " + queryKey + ": " +
-                            approovResults.getStatus().toString());
             }
         }
-        // Apply all the changes to the request
+        // gather the request changes applied to the request
+        ApproovRequestMutations changes = new ApproovRequestMutations();
+        // apply all the changes to the request
         if (aChange) {
             Request.Builder builder = request.newBuilder();
             if (setTokenHeaderKey != null) {
@@ -1142,11 +1101,8 @@ class ApproovTokenInterceptor implements Interceptor {
             request = builder.build();
         }
 
-        // Call the processed request callback
-        ApproovInterceptorExtensions extensions = ApproovService.getApproovInterceptorExtensions();
-        if (extensions != null) {
-            request = extensions.processedRequest(request, changes);
-        }
+        // call the processed request callback
+        request = mutator.handleInterceptorProcessedRequest(request, changes);
 
         // proceed with the rest of the chain
         return chain.proceed(request);
@@ -1163,20 +1119,19 @@ class ApproovPinningInterceptor implements Interceptor {
     // of different concurrent connections but without causing a significant memory leak
     private final static int maxCachedHandshakes = 10;
 
-
     // the certificate pinner to use for pinning that may be rebuilt if there is a change
     // in the pinning configuration
     private CertificatePinner certificatePinner;
 
     // set of TLS handshakes that are known to be valid constrained to a size of maxCachedHandshakes
     // to prevent a memory leak for long running apps
-    private Set<Handshake> knownValidHandshakes;
+    private java.util.LinkedHashSet<Handshake> knownValidHandshakes;
 
     /**
      * Construct a new pinning interceptor.
      */
     public ApproovPinningInterceptor() {
-        knownValidHandshakes = new HashSet<>();
+        knownValidHandshakes = new java.util.LinkedHashSet<>();
         buildPins();
     }
 
@@ -1235,13 +1190,25 @@ class ApproovPinningInterceptor implements Interceptor {
      * @param handshake to be added as known valid
      */
     synchronized private void addValidHandshake(Handshake handshake) {
-        if (knownValidHandshakes.size() >= maxCachedHandshakes)
-            knownValidHandshakes.clear();
+        while (knownValidHandshakes.size() >= maxCachedHandshakes) {
+            Iterator<Handshake> it = knownValidHandshakes.iterator();
+            if (it.hasNext()) { // can't really fail, but this keeps it safe
+                it.next();
+                it.remove();
+            }
+        }
         knownValidHandshakes.add(handshake);
     }
 
     @Override
     public Response intercept(Chain chain) throws IOException {
+        Request request = chain.request();
+        // first check if we are to proceed with any pinning processing
+        if (!ApproovService.getServiceMutator().handlePinningShouldProcessRequest(request)) {
+            // we are not to proceed with any pinning processing so just continue
+            return chain.proceed(request);
+        }
+
         String host = chain.request().url().host();
         Connection connection = chain.connection();
         Handshake handshake = (connection != null) ? connection.handshake() : null;

--- a/approov-service/src/main/java/io/approov/service/retrofit/ApproovService.java
+++ b/approov-service/src/main/java/io/approov/service/retrofit/ApproovService.java
@@ -114,7 +114,7 @@ public class ApproovService {
     private static Map<String, Pattern> exclusionURLRegexs = null;
 
     // map of cached Retrofit instances keyed by their unique builders
-    private static Map<Retrofit.Builder, Retrofit> retrofitMap = null;
+    private static Map<Retrofit.Builder, Retrofit> retrofitMap = new HashMap<>();
 
     /**
      * Construction is disallowed as this is a static only class.

--- a/approov-service/src/main/java/io/approov/service/retrofit/ApproovService.java
+++ b/approov-service/src/main/java/io/approov/service/retrofit/ApproovService.java
@@ -378,14 +378,20 @@ public class ApproovService {
     }
 
     /**
-     * Gets the interceptor extensions callback handlers.
+     * Gets the interceptor extensions callback handlers if the active mutator is an
+     * ApproovInterceptorExtensions instance, or null otherwise.
      *
-     * @return the interceptor extensions callback handlers or null if none set
+     * @return the interceptor extensions callback handlers, or null if none set or the active
+     *         mutator is not an ApproovInterceptorExtensions
      * @deprecated Use getServiceMutator instead
      */
     @Deprecated
-    public static ApproovServiceMutator getApproovInterceptorExtensions() {
-        return getServiceMutator();
+    public static ApproovInterceptorExtensions getApproovInterceptorExtensions() {
+        ApproovServiceMutator mutator = getServiceMutator();
+        if (mutator instanceof ApproovInterceptorExtensions) {
+            return (ApproovInterceptorExtensions) mutator;
+        }
+        return null;
     }
 
     /**

--- a/approov-service/src/main/java/io/approov/service/retrofit/ApproovService.java
+++ b/approov-service/src/main/java/io/approov/service/retrofit/ApproovService.java
@@ -29,7 +29,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;

--- a/approov-service/src/main/java/io/approov/service/retrofit/ApproovService.java
+++ b/approov-service/src/main/java/io/approov/service/retrofit/ApproovService.java
@@ -967,6 +967,27 @@ class ApproovTokenInterceptor implements Interceptor {
     public ApproovTokenInterceptor() {
     }
 
+    /**
+     * Determines whether a fallback Approov status should be sent in the
+     * Approov token header when a request is allowed to continue without a real
+     * token.
+     */
+    private boolean shouldSendFallbackStatusHeader(Approov.TokenFetchResult approovResults) {
+        if (!ApproovService.getUseApproovStatusIfNoToken())
+            return false;
+
+        switch (approovResults.getStatus()) {
+            case NO_NETWORK:
+            case POOR_NETWORK:
+            case MITM_DETECTED:
+            case NO_APPROOV_SERVICE:
+            case REJECTED:
+                return true;
+            default:
+                return false;
+        }
+    }
+
     @Override
     public Response intercept(Chain chain) throws IOException {
 
@@ -1008,7 +1029,8 @@ class ApproovTokenInterceptor implements Interceptor {
         String setTokenHeaderValue = null;
         String setTraceIDHeaderKey = null;
         String setTraceIDHeaderValue = null;
-        if (mutator.handleInterceptorFetchTokenResult(approovResults, url.toString())) {
+        boolean continueWithFullProcessing = mutator.handleInterceptorFetchTokenResult(approovResults, url.toString());
+        if (continueWithFullProcessing) {
             // we successfully obtained a token so add it to the header for the request
             aChange = true;
             setTokenHeaderKey = ApproovService.getApproovTokenHeader();
@@ -1016,6 +1038,22 @@ class ApproovTokenInterceptor implements Interceptor {
                 setTokenHeaderValue = ApproovService.getApproovTokenPrefix() + approovResults.getStatus().toString();
             else
                 setTokenHeaderValue = ApproovService.getApproovTokenPrefix() + approovResults.getToken();
+
+            String traceIDHeader = ApproovService.getApproovTraceIDHeader();
+            String traceID = approovResults.getTraceID();
+            if ((traceIDHeader != null) && (traceID != null) && !traceID.isEmpty()) {
+                setTraceIDHeaderKey = traceIDHeader;
+                setTraceIDHeaderValue = traceID;
+            }
+        } else if (shouldSendFallbackStatusHeader(approovResults)) {
+            // the mutator chose to proceed without a real token, but the caller
+            // has requested that failure statuses be forwarded in the token
+            // header. We continue the request with only that fallback header and
+            // skip any subsequent Approov-dependent substitution fetches.
+            aChange = true;
+            setTokenHeaderKey = ApproovService.getApproovTokenHeader();
+            setTokenHeaderValue = ApproovService.getApproovTokenPrefix() + approovResults.getStatus().toString();
+            Log.d(TAG, "Proceeding with fallback token header " + setTokenHeaderKey + ": " + setTokenHeaderValue);
 
             String traceIDHeader = ApproovService.getApproovTraceIDHeader();
             String traceID = approovResults.getTraceID();
@@ -1033,44 +1071,48 @@ class ApproovTokenInterceptor implements Interceptor {
 
         // we now deal with any header substitutions, which may require further fetches but these
         // should be using cached results
-        Map<String, String> substitutionHeaders = ApproovService.getSubstitutionHeaders();
-        Map<String, String> setSubstitutionHeaders = new java.util.LinkedHashMap<>(substitutionHeaders.size());
-        for (Map.Entry<String, String> entry : substitutionHeaders.entrySet()) {
-            String header = entry.getKey();
-            String prefix = entry.getValue();
-            String value = request.header(header);
-            if ((value != null) && value.startsWith(prefix) && (value.length() > prefix.length())) {
-                approovResults = Approov.fetchSecureStringAndWait(value.substring(prefix.length()), null);
-                Log.d(TAG, "Substituting header: " + header + ", " + approovResults.getStatus().toString());
-                if (mutator.handleInterceptorHeaderSubstitutionResult(approovResults, header)) {
-                    aChange = true;
-                    setSubstitutionHeaders.put(header, prefix + approovResults.getSecureString());
-                }
-            }
-        }
-
-        // we now deal with any query parameter substitutions, which may require further fetches but these
-        // should be using cached results
+        Map<String, String> setSubstitutionHeaders = new java.util.LinkedHashMap<>();
         String originalURL = request.url().toString();
         String replacementURL = originalURL;
-        Map<String, Pattern> substitutionQueryParams = ApproovService.getSubstitutionQueryParams();
-        List<String> queryKeys = new ArrayList<>(substitutionQueryParams.size());
-        for (Map.Entry<String, Pattern> entry : substitutionQueryParams.entrySet()) {
-            String queryKey = entry.getKey();
-            Pattern pattern = entry.getValue();
-            Matcher matcher = pattern.matcher(replacementURL);
-            if (matcher.find()) {
-                // we have found an occurrence of the query parameter to be replaced so we look up the existing
-                // value as a key for a secure string
-                String queryValue = matcher.group(1);
-                approovResults = Approov.fetchSecureStringAndWait(queryValue, null);
-                Log.d(TAG, "Substituting query parameter: " + queryKey + ", " + approovResults.getStatus().toString());
-                if (mutator.handleInterceptorQueryParamSubstitutionResult(approovResults, queryKey)) {
-                    // substitute the query parameter
-                    aChange = true;
-                    queryKeys.add(queryKey);
-                    replacementURL = new StringBuilder(replacementURL).replace(matcher.start(1),
-                            matcher.end(1), approovResults.getSecureString()).toString();
+        List<String> queryKeys = new ArrayList<>();
+        if (continueWithFullProcessing) {
+            Map<String, String> substitutionHeaders = ApproovService.getSubstitutionHeaders();
+            setSubstitutionHeaders = new java.util.LinkedHashMap<>(substitutionHeaders.size());
+            for (Map.Entry<String, String> entry : substitutionHeaders.entrySet()) {
+                String header = entry.getKey();
+                String prefix = entry.getValue();
+                String value = request.header(header);
+                if ((value != null) && value.startsWith(prefix) && (value.length() > prefix.length())) {
+                    approovResults = Approov.fetchSecureStringAndWait(value.substring(prefix.length()), null);
+                    Log.d(TAG, "Substituting header: " + header + ", " + approovResults.getStatus().toString());
+                    if (mutator.handleInterceptorHeaderSubstitutionResult(approovResults, header)) {
+                        aChange = true;
+                        setSubstitutionHeaders.put(header, prefix + approovResults.getSecureString());
+                    }
+                }
+            }
+
+            // we now deal with any query parameter substitutions, which may require further fetches but these
+            // should be using cached results
+            Map<String, Pattern> substitutionQueryParams = ApproovService.getSubstitutionQueryParams();
+            queryKeys = new ArrayList<>(substitutionQueryParams.size());
+            for (Map.Entry<String, Pattern> entry : substitutionQueryParams.entrySet()) {
+                String queryKey = entry.getKey();
+                Pattern pattern = entry.getValue();
+                Matcher matcher = pattern.matcher(replacementURL);
+                if (matcher.find()) {
+                    // we have found an occurrence of the query parameter to be replaced so we look up the existing
+                    // value as a key for a secure string
+                    String queryValue = matcher.group(1);
+                    approovResults = Approov.fetchSecureStringAndWait(queryValue, null);
+                    Log.d(TAG, "Substituting query parameter: " + queryKey + ", " + approovResults.getStatus().toString());
+                    if (mutator.handleInterceptorQueryParamSubstitutionResult(approovResults, queryKey)) {
+                        // substitute the query parameter
+                        aChange = true;
+                        queryKeys.add(queryKey);
+                        replacementURL = new StringBuilder(replacementURL).replace(matcher.start(1),
+                                matcher.end(1), approovResults.getSecureString()).toString();
+                    }
                 }
             }
         }

--- a/approov-service/src/main/java/io/approov/service/retrofit/ApproovServiceMutator.java
+++ b/approov-service/src/main/java/io/approov/service/retrofit/ApproovServiceMutator.java
@@ -1,0 +1,351 @@
+//
+// MIT License
+// 
+// Copyright (c) 2016-present, Approov Ltd.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files
+// (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR
+// ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH
+// THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+package io.approov.service.retrofit;
+
+import com.criticalblue.approovsdk.Approov;
+import okhttp3.Request;
+import java.util.regex.Pattern;
+import java.util.regex.Matcher;
+
+/**
+ * ApproovServiceMutator provides an interface for modifying the behavior of
+ * the ApproovService class by overriding the default implementations of the
+ * defined callbacks. Opportunities to modify behavior are offered at key
+ * points in the service and attestation flows.
+ *
+ * The interface provides default implementations for all methods, so
+ * implementing classes can choose to override only the methods they are
+ * interested in. The default implementations provide standard behavior
+ * that is suitable for most use cases and provides backwards compatibility
+ * with previous versions of this Approov service layer.
+ */
+public interface ApproovServiceMutator {
+    /**
+     * Default mutator that provides standard behavior with no changes.
+     */
+    public static final ApproovServiceMutator DEFAULT = new ApproovServiceMutator() {
+        @Override
+        public String toString() {
+            return "ApproovServiceMutator.DEFAULT";
+        }
+    };
+
+    /**
+     * Decides how to handle the token fetch result from an
+     * ApproovService.precheck() operation.
+     *
+     * @param approovResults the TokenFetchResult obtained by
+     *                       ApproovService.precheck()
+     * @throws ApproovException The implementation can either return, taking no
+     *                          action or throw an ApproovException encoding
+     *                          the cause of the failure.
+     */
+    @SuppressWarnings("deprecation")
+    default void handlePrecheckResult(Approov.TokenFetchResult approovResults) throws ApproovException {
+        Approov.TokenFetchStatus status = approovResults.getStatus();
+        String arc = approovResults.getARC();
+        String rejectionReasons = approovResults.getRejectionReasons();
+        switch (status) {
+            case REJECTED:
+                throw new ApproovRejectionException(
+                        "precheck: " + status.toString() + ": " + arc + " " + rejectionReasons, arc, rejectionReasons);
+            case NO_NETWORK:
+            case POOR_NETWORK:
+            case MITM_DETECTED:
+                throw new ApproovNetworkException(status, "precheck: " + status.toString());
+            case SUCCESS:
+            case UNKNOWN_KEY:
+                break;
+            default:
+                throw new ApproovFetchStatusException(status, "precheck: " + status.toString());
+        }
+    }
+
+    /**
+     * Decides how to handle the token fetch result from an
+     * ApproovService.fetchToken() operation.
+     *
+     * @param approovResults the TokenFetchResult obtained by
+     *                       ApproovService.fetchToken()
+     * @throws ApproovException The implementation can either return, taking no
+     *                          action or throw an ApproovException encoding
+     *                          the cause of the failure.
+     */
+    @SuppressWarnings("deprecation")
+    default void handleFetchTokenResult(Approov.TokenFetchResult approovResults) throws ApproovException {
+        Approov.TokenFetchStatus status = approovResults.getStatus();
+        switch (status) {
+            case NO_NETWORK:
+            case POOR_NETWORK:
+            case MITM_DETECTED:
+                throw new ApproovNetworkException(status, "fetchToken: " + status.toString());
+            case SUCCESS:
+                break;
+            default:
+                throw new ApproovFetchStatusException(status, "fetchToken: " + status.toString());
+        }
+    }
+
+    /**
+     * Decides how to handle the token fetch result from an
+     * ApproovService.fetchSecureString() operation.
+     *
+     * @param approovResults the TokenFetchResult obtained by
+     *                       ApproovService.fetchSecureString()
+     * @param operation      the operation type ("lookup" or "definition"); "lookup"
+     *                       indicates that an existing value was requested, while
+     *                       "definition" indicates that a new value was being added
+     *                       or set
+     * @param key            the secure string key
+     * @throws ApproovException The implementation can either return, taking no
+     *                          action or throw an ApproovException encoding
+     *                          the cause of the failure
+     */
+    @SuppressWarnings("deprecation")
+    default void handleFetchSecureStringResult(Approov.TokenFetchResult approovResults, String operation, String key)
+            throws ApproovException {
+        Approov.TokenFetchStatus status = approovResults.getStatus();
+        String arc = approovResults.getARC();
+        String rejectionReasons = approovResults.getRejectionReasons();
+        switch (status) {
+            case REJECTED:
+                throw new ApproovRejectionException("fetchSecureString " + operation + " for " + key + ": "
+                        + status.toString() + ": " + arc + " " + rejectionReasons, arc, rejectionReasons);
+            case NO_NETWORK:
+            case POOR_NETWORK:
+            case MITM_DETECTED:
+                throw new ApproovNetworkException(status,
+                        "fetchSecureString " + operation + " for " + key + ": " + status.toString());
+            case SUCCESS:
+            case UNKNOWN_KEY:
+                break;
+            default:
+                throw new ApproovFetchStatusException(status,
+                        "fetchSecureString " + operation + " for " + key + ": " + status.toString());
+        }
+    }
+
+    /**
+     * Decides how to handle the token fetch result from an
+     * ApproovService.fetchCustomJWT() operation.
+     *
+     * @param approovResults the TokenFetchResult obtained by
+     *                       ApproovService.fetchCustomJWT()
+     * @throws ApproovException The implementation can either return, taking no
+     *                          action or throw an ApproovException encoding
+     *                          the cause of the failure
+     */
+    @SuppressWarnings("deprecation")
+    default void handleFetchCustomJWTResult(Approov.TokenFetchResult approovResults) throws ApproovException {
+        Approov.TokenFetchStatus status = approovResults.getStatus();
+        String arc = approovResults.getARC();
+        String rejectionReasons = approovResults.getRejectionReasons();
+        switch (status) {
+            case REJECTED:
+                throw new ApproovRejectionException(
+                        "fetchCustomJWT: " + status.toString() + ": " + arc + " " + rejectionReasons, arc,
+                        rejectionReasons);
+            case NO_NETWORK:
+            case POOR_NETWORK:
+            case MITM_DETECTED:
+                throw new ApproovNetworkException(status, "fetchCustomJWT: " + status.toString());
+            case SUCCESS:
+                break;
+            default:
+                throw new ApproovFetchStatusException(status, "fetchCustomJWT: " + status.toString());
+        }
+    }
+
+    /**
+     * Decides whether a request should be processed in the interceptor or not.
+     * Called at the start of the ApproovService interceptor processing.
+     *
+     * @param request the request property extracted from the interceptor chain
+     * @return true if the request should be processed by the Approov interceptor,
+     *         false if it should be issued unchanged
+     * @throws ApproovException The implementation can either return to indicate the
+     *                          action described above or throw an ApproovException
+     *                          encoding the cause of the failure
+     */
+    default boolean handleInterceptorShouldProcessRequest(Request request) throws ApproovException {
+        if (request == null)
+            throw new ApproovException(
+                    "handleInterceptorShouldProcessRequest method was passed a request that is null!");
+
+        // check if the URL matches one of the exclusion regexs and skip interceptor
+        // processing in these cases
+        String url = request.url().toString();
+        for (Pattern pattern : ApproovService.getExclusionURLRegexs().values()) {
+            Matcher matcher = pattern.matcher(url);
+            if (matcher.find()) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Decides how to handle the token fetch result from a call to
+     * Approov.fetchApproovTokenAndWait() from within the interceptor.
+     *
+     * @param approovResults the TokenFetchResult from Approov
+     * @param url            the URL string for which the token was requested
+     * @return true if processing should continue, false if request should proceed
+     *         even though no token was obtained from the fetch
+     * @throws ApproovException The implementation can either return to indicate the
+     *                          action described above or throw an ApproovException
+     *                          encoding the cause of the failure
+     */
+    @SuppressWarnings("deprecation")
+    default boolean handleInterceptorFetchTokenResult(Approov.TokenFetchResult approovResults, String url)
+            throws ApproovException {
+        Approov.TokenFetchStatus status = approovResults.getStatus();
+        switch (status) {
+            case SUCCESS:
+                return true;
+            case NO_NETWORK:
+            case POOR_NETWORK:
+            case MITM_DETECTED:
+                if (ApproovService.getUseApproovStatusIfNoToken())
+                    return true;
+                if (!ApproovService.getProceedOnNetworkFail())
+                    throw new ApproovNetworkException(status,
+                            "Approov token fetch for " + url + ": " + status.toString());
+                return false;
+            case NO_APPROOV_SERVICE:
+            case UNKNOWN_URL:
+            case UNPROTECTED_URL: // Continue without token for unprotected URLs
+                return false;
+            default:
+                throw new ApproovFetchStatusException(status,
+                        "Approov token fetch for " + url + ": " + status.toString());
+        }
+    }
+
+    /**
+     * Decides how to handle the token fetch result while substituting headers from
+     * within the interceptor. The passed fetch result to process is associated with
+     * a preceding call to Approov.fetchSecureStringAndWait which passed in the
+     * current header value (minus a prefix) as the key. This method is called once
+     * per header being processed for substitution.
+     *
+     * @param approovResults the TokenFetchResult from Approov
+     * @param header         the header being substituted
+     * @return true if substitution should proceed, false if it should be skipped
+     * @throws ApproovException The implementation can either return to indicate the
+     *                          action described above or throw an ApproovException
+     *                          encoding the cause of the failure
+     */
+    @SuppressWarnings("deprecation")
+    default boolean handleInterceptorHeaderSubstitutionResult(Approov.TokenFetchResult approovResults, String header)
+            throws ApproovException {
+        Approov.TokenFetchStatus status = approovResults.getStatus();
+        String arc = approovResults.getARC();
+        String rejectionReasons = approovResults.getRejectionReasons();
+        switch (status) {
+            case SUCCESS:
+                return true;
+            case REJECTED:
+                throw new ApproovRejectionException("Header substitution for " + header + ": " + status.toString()
+                        + ": " + arc + " " + rejectionReasons, arc, rejectionReasons);
+            case NO_NETWORK:
+            case POOR_NETWORK:
+            case MITM_DETECTED:
+                if (!ApproovService.getProceedOnNetworkFail())
+                    throw new ApproovNetworkException(status,
+                            "Header substitution for " + header + ": " + status.toString());
+                return false;
+            case UNKNOWN_KEY:
+                return false;
+            default:
+                throw new ApproovFetchStatusException(status,
+                        "Header substitution for " + header + ": " + status.toString());
+        }
+    }
+
+    /**
+     * Decides how to handle the token fetch result while substituting query params
+     * from within the interceptor. The passed fetch result to process is associated
+     * with a preceding call to Approov.fetchSecureStringAndWait which passed in the
+     * query value of a matching query key. This method is called once for each
+     * matched
+     * query parameter being processed for substitution.
+     *
+     * @param approovResults the TokenFetchResult from Approov
+     * @param queryKey       the query parameter key being substituted
+     * @return true if substitution should proceed, false if it should be skipped
+     * @throws ApproovException The implementation can either return to indicate the
+     *                          action described above or throw an ApproovException
+     *                          encoding the cause of the failure
+     */
+    @SuppressWarnings("deprecation")
+    default boolean handleInterceptorQueryParamSubstitutionResult(Approov.TokenFetchResult approovResults,
+            String queryKey) throws ApproovException {
+        Approov.TokenFetchStatus status = approovResults.getStatus();
+        String arc = approovResults.getARC();
+        String rejectionReasons = approovResults.getRejectionReasons();
+        switch (status) {
+            case SUCCESS:
+                return true;
+            case REJECTED:
+                throw new ApproovRejectionException("Query parameter substitution for " + queryKey + ": "
+                        + status.toString() + ": " + arc + " " + rejectionReasons, arc, rejectionReasons);
+            case NO_NETWORK:
+            case POOR_NETWORK:
+            case MITM_DETECTED:
+                if (!ApproovService.getProceedOnNetworkFail())
+                    throw new ApproovNetworkException(status,
+                            "Query parameter substitution for " + queryKey + ": " + status.toString());
+                return false;
+            case UNKNOWN_KEY:
+                return false;
+            default:
+                throw new ApproovFetchStatusException(status,
+                        "Query parameter substitution for " + queryKey + ": " + status.toString());
+        }
+    }
+
+    /**
+     * Called after Approov has processed a network request, allowing further
+     * modifications.
+     *
+     * @param request the processed request
+     * @param changes the mutations applied to the request by Approov
+     * @return the final request to use to complete the Approov interceptor step.
+     * @throws ApproovException The implementation can either return as described
+     *                          above or throw an ApproovException encoding the
+     *                          cause of the failure
+     */
+    default Request handleInterceptorProcessedRequest(Request request, ApproovRequestMutations changes)
+            throws ApproovException {
+        // No further changes to the request are required
+        return request;
+    }
+
+    /**
+     * Decides whether certificate pinning should be applied to a request or not.
+     * Called at the start of the ApproovService pinning processing.
+     *
+     * @param request the request being processed
+     * @return true if pinning should be applied, false to skip it
+     */
+    default boolean handlePinningShouldProcessRequest(Request request) {
+        // By default do not skip pinning for any requests
+        return true;
+    }
+}

--- a/approov-service/src/main/java/io/approov/util/http/sfv/Parameters.java
+++ b/approov-service/src/main/java/io/approov/util/http/sfv/Parameters.java
@@ -18,6 +18,7 @@ import java.util.function.Function;
  *      "https://www.rfc-editor.org/rfc/rfc8941.html#param">Section
  *      3.1.2 of RFC 8941</a>
  */
+@android.annotation.SuppressLint("NewApi")
 public class Parameters implements Map<String, Item<?>> {
 
     private final Map<String, Item<?>> delegate;
@@ -115,7 +116,9 @@ public class Parameters implements Map<String, Item<?>> {
     }
 
     public void forEach(BiConsumer<? super String, ? super Item<?>> action) {
-        delegate.forEach(action);
+        for (Map.Entry<String, Item<?>> entry : delegate.entrySet()) {
+            action.accept(entry.getKey(), entry.getValue());
+        }
     }
 
     public Item<?> get(Object key) {
@@ -123,7 +126,10 @@ public class Parameters implements Map<String, Item<?>> {
     }
 
     public Item<?> getOrDefault(Object key, Item<?> defaultValue) {
-        return delegate.getOrDefault(key, defaultValue);
+        if (delegate.containsKey(key)) {
+            return delegate.get(key);
+        }
+        return defaultValue;
     }
 
     public int hashCode() {

--- a/approov-service/src/test/java/io/approov/service/retrofit/ApproovDefaultMessageSigningContractTest.java
+++ b/approov-service/src/test/java/io/approov/service/retrofit/ApproovDefaultMessageSigningContractTest.java
@@ -1,0 +1,170 @@
+package io.approov.service.retrofit;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+import okhttp3.MediaType;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+
+import org.junit.Test;
+
+public class ApproovDefaultMessageSigningContractTest {
+
+    private static final MediaType APPLICATION_JSON = MediaType.get("application/json");
+
+    private static final class RecordingSigner extends ApproovDefaultMessageSigning {
+        private String installSignatureBase64 = "";
+        private String accountSignatureBase64 = "";
+        private ApproovException installError;
+        private String lastInstallMessage;
+        private String lastAccountMessage;
+
+        @Override
+        protected String getInstallMessageSignature(String message) throws ApproovException {
+            lastInstallMessage = message;
+            if (installError != null) {
+                throw installError;
+            }
+            return installSignatureBase64;
+        }
+
+        @Override
+        protected String getAccountMessageSignature(String message) {
+            lastAccountMessage = message;
+            return accountSignatureBase64;
+        }
+
+        @Override
+        protected byte[] decodeBase64(String base64) {
+            return Base64.getDecoder().decode(base64);
+        }
+    }
+
+    private static String derEncodedInstallSignature() {
+        byte[] der = new byte[] { 0x30, 0x06, 0x02, 0x01, 0x01, 0x02, 0x01, 0x02 };
+        return Base64.getEncoder().encodeToString(der);
+    }
+
+    private static Request signedRequestFixture() {
+        return new Request.Builder()
+                .url("https://api.example.com/reply")
+                .post(RequestBody.create(APPLICATION_JSON, "{\"hello\":\"world\"}".getBytes(StandardCharsets.UTF_8)))
+                .header("Approov-Token", "Bearer jwt-token")
+                .header("Approov-TraceID", "trace-123")
+                .header("Authorization", "Bearer auth-token")
+                .header("Content-Type", "application/json")
+                .header("Content-Digest", "stale-digest")
+                .header("Signature", "stale-signature")
+                .header("Signature-Input", "stale-input")
+                .header("Signature-Base-Digest", "stale-base-digest")
+                .build();
+    }
+
+    private static ApproovRequestMutations defaultChanges() {
+        ApproovRequestMutations changes = new ApproovRequestMutations();
+        changes.setTokenHeaderKey("Approov-Token");
+        changes.setTraceIDHeaderKey("Approov-TraceID");
+        return changes;
+    }
+
+    @Test
+    public void defaultSigningAddsDigestAndSignatureHeaders() throws Exception {
+        RecordingSigner signer = new RecordingSigner();
+        signer.setDefaultFactory(ApproovDefaultMessageSigning.generateDefaultSignatureParametersFactory());
+        signer.installSignatureBase64 = derEncodedInstallSignature();
+
+        Request signed = signer.processedRequest(signedRequestFixture(), defaultChanges());
+
+        assertTrue(signer.lastInstallMessage.contains("\"@method\""));
+        assertTrue(signer.lastInstallMessage.contains("\"@target-uri\""));
+        assertTrue(signer.lastInstallMessage.contains("\"approov-token\""));
+        assertTrue(signer.lastInstallMessage.contains("\"approov-traceid\""));
+        assertTrue(signer.lastInstallMessage.contains("\"content-digest\""));
+        assertEquals("Bearer jwt-token", signed.header("Approov-Token"));
+        assertEquals("trace-123", signed.header("Approov-TraceID"));
+        assertTrue(signed.header("Content-Digest").contains("sha-256=:"));
+        assertTrue(signed.header("Signature").contains("install=:"));
+        assertTrue(signed.header("Signature-Input").contains("install=("));
+        assertFalse(signed.header("Signature").contains("stale-signature"));
+        assertFalse(signed.header("Signature-Input").contains("stale-input"));
+        assertNull(signed.header("Signature-Base-Digest"));
+        assertEquals(1, signed.headers("Content-Digest").size());
+        assertEquals(1, signed.headers("Signature").size());
+        assertEquals(1, signed.headers("Signature-Input").size());
+    }
+
+    @Test
+    public void signingTwiceReplacesExistingSignatureAndDigestHeaders() throws Exception {
+        RecordingSigner signer = new RecordingSigner();
+        signer.setDefaultFactory(ApproovDefaultMessageSigning.generateDefaultSignatureParametersFactory());
+        signer.installSignatureBase64 = derEncodedInstallSignature();
+
+        Request signedOnce = signer.processedRequest(signedRequestFixture(), defaultChanges());
+        Request signedTwice = signer.processedRequest(signedOnce, defaultChanges());
+
+        assertEquals(1, signedTwice.headers("Content-Digest").size());
+        assertEquals(1, signedTwice.headers("Signature").size());
+        assertEquals(1, signedTwice.headers("Signature-Input").size());
+        assertFalse(signedTwice.header("Signature").contains("stale-signature"));
+        assertFalse(signedTwice.header("Signature-Input").contains("stale-input"));
+        assertNull(signedTwice.header("Signature-Base-Digest"));
+    }
+
+    @Test
+    public void signingWithoutAnApproovTokenMutationLeavesTheRequestUnchanged() throws Exception {
+        RecordingSigner signer = new RecordingSigner();
+        signer.setDefaultFactory(ApproovDefaultMessageSigning.generateDefaultSignatureParametersFactory());
+        signer.installSignatureBase64 = derEncodedInstallSignature();
+        Request request = signedRequestFixture();
+
+        Request signed = signer.processedRequest(request, new ApproovRequestMutations());
+
+        assertSame(request, signed);
+        assertEquals("stale-signature", signed.header("Signature"));
+        assertEquals("stale-input", signed.header("Signature-Input"));
+        assertEquals("stale-digest", signed.header("Content-Digest"));
+    }
+
+    @Test
+    public void signingSkipsGracefullyWhenInstallSigningIsUnavailable() throws Exception {
+        RecordingSigner signer = new RecordingSigner();
+        signer.setDefaultFactory(ApproovDefaultMessageSigning.generateDefaultSignatureParametersFactory());
+        signer.installError = new ApproovException("no device signature available");
+        Request request = signedRequestFixture().newBuilder()
+                .removeHeader("Content-Digest")
+                .removeHeader("Signature")
+                .removeHeader("Signature-Input")
+                .removeHeader("Signature-Base-Digest")
+                .build();
+
+        Request signed = signer.processedRequest(request, defaultChanges());
+
+        assertSame(request, signed);
+        assertNull(signed.header("Content-Digest"));
+        assertNull(signed.header("Signature"));
+        assertNull(signed.header("Signature-Input"));
+        assertNull(signed.header("Signature-Base-Digest"));
+    }
+
+    @Test
+    public void accountSigningUsesTheAccountSignatureFlow() throws Exception {
+        RecordingSigner signer = new RecordingSigner();
+        signer.setDefaultFactory(ApproovDefaultMessageSigning.generateDefaultSignatureParametersFactory()
+                .setUseAccountMessageSigning());
+        signer.accountSignatureBase64 = Base64.getEncoder().encodeToString("account-signature".getBytes(StandardCharsets.UTF_8));
+
+        Request signed = signer.processedRequest(signedRequestFixture(), defaultChanges());
+
+        assertTrue(signed.header("Signature").contains("account=:"));
+        assertTrue(signed.header("Signature-Input").contains("account=("));
+        assertNull(signer.lastInstallMessage);
+        assertTrue(signer.lastAccountMessage.contains("\"approov-token\""));
+    }
+}

--- a/approov-service/src/test/java/io/approov/service/retrofit/ApproovServiceContractTest.java
+++ b/approov-service/src/test/java/io/approov/service/retrofit/ApproovServiceContractTest.java
@@ -1,0 +1,140 @@
+package io.approov.service.retrofit;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mockStatic;
+
+import com.criticalblue.approovsdk.Approov;
+
+import okhttp3.OkHttpClient;
+import retrofit2.Retrofit;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.MockedStatic;
+
+public class ApproovServiceContractTest {
+
+    @Before
+    public void setUp() {
+        ApproovTestSupport.resetApproovServiceState();
+    }
+
+    @After
+    public void tearDown() {
+        ApproovTestSupport.resetApproovServiceState();
+    }
+
+    @Test
+    public void getRetrofitSupportsPreInitializationBuilderConfiguration() {
+        OkHttpClient.Builder okHttpBuilder = new OkHttpClient.Builder()
+                .retryOnConnectionFailure(false);
+        Retrofit.Builder retrofitBuilder = new Retrofit.Builder()
+                .baseUrl("https://example.com/");
+
+        ApproovService.setOkHttpClientBuilder(okHttpBuilder);
+
+        Retrofit first = ApproovService.getRetrofit(retrofitBuilder);
+        Retrofit second = ApproovService.getRetrofit(retrofitBuilder);
+        OkHttpClient client = ApproovTestSupport.retrofitClient(first);
+
+        assertNotNull(first);
+        assertSame(first, second);
+        assertFalse(client.retryOnConnectionFailure());
+        assertTrue(client.interceptors().stream().noneMatch(interceptor -> interceptor instanceof ApproovTokenInterceptor));
+        assertTrue(client.networkInterceptors().stream().noneMatch(interceptor -> interceptor instanceof ApproovPinningInterceptor));
+    }
+
+    @Test
+    public void initializeRestoresDefaultHeadersAndTraceIdConfiguration() {
+        try (MockedStatic<Approov> approov = mockStatic(Approov.class)) {
+            ApproovTestSupport.initializeApproovService(approov);
+
+            assertEquals("Approov-Token", ApproovService.getApproovTokenHeader());
+            assertEquals("", ApproovService.getApproovTokenPrefix());
+            assertEquals("Approov-TraceID", ApproovService.getApproovTraceIDHeader());
+
+            ApproovService.setApproovTraceIDHeader(null);
+
+            assertEquals(null, ApproovService.getApproovTraceIDHeader());
+            approov.verify(() -> Approov.setUserProperty("approov-service-retrofit"));
+        }
+    }
+
+    @Test
+    public void fetchTokenReturnsTheSdkTokenOnSuccess() throws Exception {
+        try (MockedStatic<Approov> approov = mockStatic(Approov.class)) {
+            Approov.TokenFetchResult successResult = ApproovTestSupport.tokenResult(
+                    Approov.TokenFetchStatus.SUCCESS,
+                    "jwt-token",
+                    "",
+                    "trace-123",
+                    false);
+            approov.when(() -> Approov.fetchApproovTokenAndWait("https://example.com/reply"))
+                    .thenReturn(successResult);
+
+            assertEquals("jwt-token", ApproovService.fetchToken("https://example.com/reply"));
+        }
+    }
+
+    @Test
+    public void fetchTokenThrowsNetworkExceptionForNoNetwork() {
+        try (MockedStatic<Approov> approov = mockStatic(Approov.class)) {
+            Approov.TokenFetchResult noNetworkResult =
+                    ApproovTestSupport.tokenResult(Approov.TokenFetchStatus.NO_NETWORK);
+            approov.when(() -> Approov.fetchApproovTokenAndWait("https://example.com/reply"))
+                    .thenReturn(noNetworkResult);
+
+            ApproovNetworkException error = assertThrows(
+                    ApproovNetworkException.class,
+                    () -> ApproovService.fetchToken("https://example.com/reply"));
+
+            assertEquals(Approov.TokenFetchStatus.NO_NETWORK, error.getTokenFetchStatus());
+        }
+    }
+
+    @Test
+    public void fetchSecureStringAllowsUnknownKeysAndReturnsNull() throws Exception {
+        try (MockedStatic<Approov> approov = mockStatic(Approov.class)) {
+            Approov.TokenFetchResult unknownKeyResult = ApproovTestSupport.tokenResult(
+                    Approov.TokenFetchStatus.UNKNOWN_KEY,
+                    "",
+                    null,
+                    "",
+                    false);
+            approov.when(() -> Approov.fetchSecureStringAndWait("missing-key", null))
+                    .thenReturn(unknownKeyResult);
+
+            assertEquals(null, ApproovService.fetchSecureString("missing-key", null));
+        }
+    }
+
+    @Test
+    public void accountMessageSignatureReturnsTheSdkValue() throws Exception {
+        try (MockedStatic<Approov> approov = mockStatic(Approov.class)) {
+            approov.when(() -> Approov.getAccountMessageSignature("message"))
+                    .thenReturn("base64-account-signature");
+
+            assertEquals("base64-account-signature", ApproovService.getAccountMessageSignature("message"));
+        }
+    }
+
+    @Test
+    public void installMessageSignatureWrapsPlatformSigningFailures() {
+        try (MockedStatic<Approov> approov = mockStatic(Approov.class)) {
+            approov.when(() -> Approov.getInstallMessageSignature("message"))
+                    .thenThrow(new IllegalStateException("private key unavailable"));
+
+            ApproovException error = assertThrows(
+                    ApproovException.class,
+                    () -> ApproovService.getInstallMessageSignature("message"));
+
+            assertTrue(error.getMessage().contains("IllegalState: private key unavailable"));
+        }
+    }
+}

--- a/approov-service/src/test/java/io/approov/service/retrofit/ApproovTestSupport.java
+++ b/approov-service/src/test/java/io/approov/service/retrofit/ApproovTestSupport.java
@@ -1,0 +1,125 @@
+package io.approov.service.retrofit;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import android.content.Context;
+
+import com.criticalblue.approovsdk.Approov;
+
+import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+import okhttp3.Interceptor;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Protocol;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+import retrofit2.Retrofit;
+
+import org.mockito.MockedStatic;
+
+final class ApproovTestSupport {
+
+    private static final MediaType TEXT_PLAIN = MediaType.get("text/plain");
+
+    private ApproovTestSupport() {
+    }
+
+    static void resetApproovServiceState() {
+        setStaticField("isInitialized", false);
+        setStaticField("configString", null);
+        setStaticField("proceedOnNetworkFail", false);
+        setStaticField("useApproovStatusIfNoToken", false);
+        setStaticField("pinningInterceptor", null);
+        setStaticField("okHttpBuilder", null);
+        setStaticField("approovTokenHeader", null);
+        setStaticField("approovTokenPrefix", null);
+        setStaticField("approovTraceIDHeader", null);
+        setStaticField("bindingHeader", null);
+        setStaticField("serviceMutator", ApproovServiceMutator.DEFAULT);
+        setStaticField("substitutionHeaders", new HashMap<String, String>());
+        setStaticField("substitutionQueryParams", new HashMap<String, Pattern>());
+        setStaticField("exclusionURLRegexs", new HashMap<String, Pattern>());
+        setStaticField("retrofitMap", new HashMap<Retrofit.Builder, Retrofit>());
+    }
+
+    static void initializeApproovService(MockedStatic<Approov> approov) {
+        resetApproovServiceState();
+        approov.when(() -> Approov.getPins("public-key-sha256")).thenReturn(new HashMap<>());
+        Context context = mock(Context.class);
+        when(context.getApplicationContext()).thenReturn(context);
+        ApproovService.initialize(context, "", "reinit-tests");
+    }
+
+    static Approov.TokenFetchResult tokenResult(Approov.TokenFetchStatus status) {
+        return tokenResult(status, "", "", "", false);
+    }
+
+    static Approov.TokenFetchResult tokenResult(
+            Approov.TokenFetchStatus status,
+            String token,
+            String secureString,
+            String traceID,
+            boolean configChanged
+    ) {
+        Approov.TokenFetchResult result = mock(Approov.TokenFetchResult.class);
+        when(result.getStatus()).thenReturn(status);
+        when(result.getToken()).thenReturn(token);
+        when(result.getSecureString()).thenReturn(secureString);
+        when(result.getTraceID()).thenReturn(traceID);
+        when(result.getLoggableToken()).thenReturn(token);
+        when(result.getARC()).thenReturn("ARC123");
+        when(result.getRejectionReasons()).thenReturn("hooked,rooted");
+        when(result.isConfigChanged()).thenReturn(configChanged);
+        return result;
+    }
+
+    static Interceptor.Chain interceptorChain(Request request) throws Exception {
+        Interceptor.Chain chain = mock(Interceptor.Chain.class);
+        when(chain.request()).thenReturn(request);
+        when(chain.connection()).thenReturn(null);
+        when(chain.proceed(any(Request.class))).thenAnswer(invocation -> successResponse(invocation.getArgument(0)));
+        return chain;
+    }
+
+    static Response successResponse(Request request) {
+        return new Response.Builder()
+                .request(request)
+                .protocol(Protocol.HTTP_1_1)
+                .code(200)
+                .message("OK")
+                .body(ResponseBody.create("ok", TEXT_PLAIN))
+                .build();
+    }
+
+    static OkHttpClient retrofitClient(Retrofit retrofit) {
+        return (OkHttpClient) retrofit.callFactory();
+    }
+
+    @SuppressWarnings("unchecked")
+    static <T> T getStaticField(String name, Class<T> type) {
+        try {
+            Field field = ApproovService.class.getDeclaredField(name);
+            field.setAccessible(true);
+            return (T) field.get(null);
+        } catch (ReflectiveOperationException e) {
+            throw new AssertionError("Failed to read field " + name, e);
+        }
+    }
+
+    private static void setStaticField(String name, Object value) {
+        try {
+            Field field = ApproovService.class.getDeclaredField(name);
+            field.setAccessible(true);
+            field.set(null, value);
+        } catch (ReflectiveOperationException e) {
+            throw new AssertionError("Failed to reset field " + name, e);
+        }
+    }
+}

--- a/approov-service/src/test/java/io/approov/service/retrofit/ApproovTokenInterceptorContractTest.java
+++ b/approov-service/src/test/java/io/approov/service/retrofit/ApproovTokenInterceptorContractTest.java
@@ -1,0 +1,280 @@
+package io.approov.service.retrofit;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mockStatic;
+
+import com.criticalblue.approovsdk.Approov;
+
+import java.util.Arrays;
+
+import okhttp3.Request;
+import okhttp3.Response;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.MockedStatic;
+
+public class ApproovTokenInterceptorContractTest {
+
+    private static final class RecordingMutator implements ApproovServiceMutator {
+        private final boolean allowProceed;
+        private final String extraHeaderValue;
+        private final Approov.TokenFetchStatus forceFalseStatus;
+        private ApproovRequestMutations capturedChanges;
+
+        RecordingMutator(boolean allowProceed, String extraHeaderValue) {
+            this(allowProceed, extraHeaderValue, null);
+        }
+
+        RecordingMutator(boolean allowProceed, String extraHeaderValue, Approov.TokenFetchStatus forceFalseStatus) {
+            this.allowProceed = allowProceed;
+            this.extraHeaderValue = extraHeaderValue;
+            this.forceFalseStatus = forceFalseStatus;
+        }
+
+        @Override
+        public boolean handleInterceptorFetchTokenResult(Approov.TokenFetchResult approovResults, String url)
+                throws ApproovException {
+            if (forceFalseStatus != null && approovResults.getStatus() == forceFalseStatus) {
+                return false;
+            }
+            if (approovResults.getStatus() == Approov.TokenFetchStatus.NO_APPROOV_SERVICE) {
+                if (!allowProceed) {
+                    throw new ApproovNetworkException("custom block");
+                }
+                return false;
+            }
+            return ApproovServiceMutator.super.handleInterceptorFetchTokenResult(approovResults, url);
+        }
+
+        @Override
+        public Request handleInterceptorProcessedRequest(Request request, ApproovRequestMutations changes) {
+            capturedChanges = changes;
+            if (extraHeaderValue == null) {
+                return request;
+            }
+            return request.newBuilder()
+                    .header("X-Mutated", extraHeaderValue)
+                    .build();
+        }
+    }
+
+    @Before
+    public void setUp() {
+        ApproovTestSupport.resetApproovServiceState();
+    }
+
+    @After
+    public void tearDown() {
+        ApproovService.setServiceMutator(ApproovServiceMutator.DEFAULT);
+        ApproovTestSupport.resetApproovServiceState();
+    }
+
+    @Test
+    public void interceptorAddsApproovTokenTraceIdAndMutatorChangesOnSuccess() throws Exception {
+        try (MockedStatic<Approov> approov = mockStatic(Approov.class)) {
+            ApproovTestSupport.initializeApproovService(approov);
+            ApproovService.setApproovHeader("Approov-Token", "Bearer ");
+            RecordingMutator mutator = new RecordingMutator(true, "yes");
+            ApproovService.setServiceMutator(mutator);
+
+            Request request = new Request.Builder()
+                    .url("https://api.example.com/reply")
+                    .build();
+            Approov.TokenFetchResult successResult = ApproovTestSupport.tokenResult(
+                    Approov.TokenFetchStatus.SUCCESS,
+                    "jwt-token",
+                    "",
+                    "trace-123",
+                    false);
+            approov.when(() -> Approov.fetchApproovTokenAndWait("https://api.example.com/reply"))
+                    .thenReturn(successResult);
+
+            Response response = new ApproovTokenInterceptor().intercept(ApproovTestSupport.interceptorChain(request));
+            Request proceeded = response.request();
+
+            assertEquals("Bearer jwt-token", proceeded.header("Approov-Token"));
+            assertEquals("trace-123", proceeded.header("Approov-TraceID"));
+            assertEquals("yes", proceeded.header("X-Mutated"));
+            assertNotNull(mutator.capturedChanges);
+            assertEquals("Approov-Token", mutator.capturedChanges.getTokenHeaderKey());
+            assertEquals("Approov-TraceID", mutator.capturedChanges.getTraceIDHeaderKey());
+            assertNull(mutator.capturedChanges.getSubstitutionHeaderKeys());
+            assertNull(mutator.capturedChanges.getSubstitutionQueryParamKeys());
+        }
+    }
+
+    @Test
+    public void interceptorUsesFetchStatusAsTokenValueWhenConfigured() throws Exception {
+        try (MockedStatic<Approov> approov = mockStatic(Approov.class)) {
+            ApproovTestSupport.initializeApproovService(approov);
+            ApproovService.setUseApproovStatusIfNoToken(true);
+
+            Request request = new Request.Builder()
+                    .url("https://api.example.com/reply")
+                    .build();
+            Approov.TokenFetchResult mitmResult =
+                    ApproovTestSupport.tokenResult(Approov.TokenFetchStatus.MITM_DETECTED);
+            approov.when(() -> Approov.fetchApproovTokenAndWait("https://api.example.com/reply"))
+                    .thenReturn(mitmResult);
+
+            Response response = new ApproovTokenInterceptor().intercept(ApproovTestSupport.interceptorChain(request));
+            Request proceeded = response.request();
+
+            assertEquals("MITM_DETECTED", proceeded.header("Approov-Token"));
+            assertNull(proceeded.header("Approov-TraceID"));
+        }
+    }
+
+    @Test
+    public void interceptorKeepsFallbackStatusHeaderWhenMutatorReturnsFalse() throws Exception {
+        try (MockedStatic<Approov> approov = mockStatic(Approov.class)) {
+            ApproovTestSupport.initializeApproovService(approov);
+            ApproovService.setUseApproovStatusIfNoToken(true);
+            ApproovService.setServiceMutator(new RecordingMutator(
+                    true,
+                    null,
+                    Approov.TokenFetchStatus.MITM_DETECTED));
+
+            Request request = new Request.Builder()
+                    .url("https://api.example.com/reply")
+                    .build();
+            Approov.TokenFetchResult mitmResult =
+                    ApproovTestSupport.tokenResult(Approov.TokenFetchStatus.MITM_DETECTED);
+            approov.when(() -> Approov.fetchApproovTokenAndWait("https://api.example.com/reply"))
+                    .thenReturn(mitmResult);
+
+            Response response = new ApproovTokenInterceptor().intercept(ApproovTestSupport.interceptorChain(request));
+            Request proceeded = response.request();
+
+            assertEquals("MITM_DETECTED", proceeded.header("Approov-Token"));
+            assertNull(proceeded.header("Approov-TraceID"));
+        }
+    }
+
+    @Test
+    public void interceptorSkipsTokenAndTraceHeadersOnNoApproovService() throws Exception {
+        try (MockedStatic<Approov> approov = mockStatic(Approov.class)) {
+            ApproovTestSupport.initializeApproovService(approov);
+
+            Request request = new Request.Builder()
+                    .url("https://api.example.com/reply")
+                    .build();
+            Approov.TokenFetchResult noServiceResult =
+                    ApproovTestSupport.tokenResult(Approov.TokenFetchStatus.NO_APPROOV_SERVICE);
+            approov.when(() -> Approov.fetchApproovTokenAndWait("https://api.example.com/reply"))
+                    .thenReturn(noServiceResult);
+
+            Response response = new ApproovTokenInterceptor().intercept(ApproovTestSupport.interceptorChain(request));
+            Request proceeded = response.request();
+
+            assertNull(proceeded.header("Approov-Token"));
+            assertNull(proceeded.header("Approov-TraceID"));
+        }
+    }
+
+    @Test
+    public void interceptorSupportsSecureStringHeaderAndQuerySubstitutions() throws Exception {
+        try (MockedStatic<Approov> approov = mockStatic(Approov.class)) {
+            ApproovTestSupport.initializeApproovService(approov);
+            ApproovService.setApproovHeader("Approov-Token", "Bearer ");
+            ApproovService.addSubstitutionHeader("Api-Key", "Bearer ");
+            ApproovService.addSubstitutionQueryParam("secret");
+            RecordingMutator mutator = new RecordingMutator(true, null);
+            ApproovService.setServiceMutator(mutator);
+
+            Request request = new Request.Builder()
+                    .url("https://api.example.com/reply?secret=query-secret")
+                    .header("Api-Key", "Bearer header-secret")
+                    .build();
+            Approov.TokenFetchResult tokenResult = ApproovTestSupport.tokenResult(
+                    Approov.TokenFetchStatus.SUCCESS,
+                    "jwt-token",
+                    "",
+                    "",
+                    false);
+            Approov.TokenFetchResult headerResult = ApproovTestSupport.tokenResult(
+                    Approov.TokenFetchStatus.SUCCESS,
+                    "",
+                    "live-header",
+                    "",
+                    false);
+            Approov.TokenFetchResult queryResult = ApproovTestSupport.tokenResult(
+                    Approov.TokenFetchStatus.SUCCESS,
+                    "",
+                    "live-query",
+                    "",
+                    false);
+            approov.when(() -> Approov.fetchApproovTokenAndWait("https://api.example.com/reply?secret=query-secret"))
+                    .thenReturn(tokenResult);
+            approov.when(() -> Approov.fetchSecureStringAndWait("header-secret", null))
+                    .thenReturn(headerResult);
+            approov.when(() -> Approov.fetchSecureStringAndWait("query-secret", null))
+                    .thenReturn(queryResult);
+
+            Response response = new ApproovTokenInterceptor().intercept(ApproovTestSupport.interceptorChain(request));
+            Request proceeded = response.request();
+
+            assertEquals("Bearer jwt-token", proceeded.header("Approov-Token"));
+            assertEquals("Bearer live-header", proceeded.header("Api-Key"));
+            assertTrue(proceeded.url().toString().contains("secret=live-query"));
+            assertNotNull(mutator.capturedChanges);
+            assertEquals(Arrays.asList("Api-Key"), mutator.capturedChanges.getSubstitutionHeaderKeys());
+            assertEquals("https://api.example.com/reply?secret=query-secret", mutator.capturedChanges.getOriginalURL());
+            assertEquals(Arrays.asList("secret"), mutator.capturedChanges.getSubstitutionQueryParamKeys());
+        }
+    }
+
+    @Test
+    public void interceptorCanDisableTraceIdHeaderEvenWhenTheSdkProvidesOne() throws Exception {
+        try (MockedStatic<Approov> approov = mockStatic(Approov.class)) {
+            ApproovTestSupport.initializeApproovService(approov);
+            ApproovService.setApproovTraceIDHeader(null);
+
+            Request request = new Request.Builder()
+                    .url("https://api.example.com/reply")
+                    .build();
+            Approov.TokenFetchResult successResult = ApproovTestSupport.tokenResult(
+                    Approov.TokenFetchStatus.SUCCESS,
+                    "jwt-token",
+                    "",
+                    "trace-123",
+                    false);
+            approov.when(() -> Approov.fetchApproovTokenAndWait("https://api.example.com/reply"))
+                    .thenReturn(successResult);
+
+            Response response = new ApproovTokenInterceptor().intercept(ApproovTestSupport.interceptorChain(request));
+
+            assertEquals("jwt-token", response.request().header("Approov-Token"));
+            assertFalse(response.request().headers().names().contains("Approov-TraceID"));
+        }
+    }
+
+    @Test
+    public void customMutatorCanBlockNoApproovServiceRequests() throws Exception {
+        try (MockedStatic<Approov> approov = mockStatic(Approov.class)) {
+            ApproovTestSupport.initializeApproovService(approov);
+            ApproovService.setServiceMutator(new RecordingMutator(false, null));
+
+            Request request = new Request.Builder()
+                    .url("https://api.example.com/reply")
+                    .build();
+            Approov.TokenFetchResult noServiceResult =
+                    ApproovTestSupport.tokenResult(Approov.TokenFetchStatus.NO_APPROOV_SERVICE);
+            approov.when(() -> Approov.fetchApproovTokenAndWait("https://api.example.com/reply"))
+                    .thenReturn(noServiceResult);
+
+            ApproovNetworkException error = assertThrows(
+                    ApproovNetworkException.class,
+                    () -> new ApproovTokenInterceptor().intercept(ApproovTestSupport.interceptorChain(request)));
+
+            assertEquals("custom block", error.getMessage());
+        }
+    }
+}


### PR DESCRIPTION
This branch modernizes the Retrofit wrapper around the new `ApproovServiceMutator` model, improves fallback behavior when token fetches fail, hardens message signing, and adds documentation plus test coverage for the new behavior.


- Introduces `ApproovServiceMutator` as the main policy/customization surface in `ApproovServiceMutator.java`, and keeps `ApproovInterceptorExtensions` as a compatibility layer.
- Refactors `ApproovService.java` to route decisions through the mutator, fixes `retrofitMap` initialization for pre-initialize use, and adds fallback `Approov-Token: <STATUS>` support when requests are allowed to continue without a real token.
- Improves `ApproovDefaultMessageSigning.java` so missing install signatures are handled gracefully and repeated signing replaces stale signature/digest headers instead of accumulating duplicates.
- Adds/updates exception types and messaging around fetch-status handling in `ApproovFetchStatusException.java`, `ApproovNetworkException.java`, and `ApproovRejectionException.java`.
- Expands docs in `REFERENCE.md`, `USAGE.md`, `README.md`, and `CHANGELOG.md` to document mutator usage, status fallback behavior, and the obsolete `setApproovInterceptorExtensions` API.
- Aligns publish/test metadata in `approov-service/build.gradle` and `approov-service/pom.xml`.
- Adds JVM test coverage with contract, regression, and unit tests in:
  - `ApproovServiceContractTest.java`
  - `ApproovTokenInterceptorContractTest.java`
  - `ApproovDefaultMessageSigningContractTest.java`
  - `ApproovTestSupport.java`

