### PR TITLE
Feature/use mini sdk

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -23,10 +23,10 @@ jobs:
       run: git config --global --add safe.directory '*'
       
     - name: Checkout Repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Set Up Java
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
         distribution: 'temurin' # Use Eclipse Temurin distribution
         java-version: '21'      # Use Java 21 for Android builds
@@ -80,7 +80,7 @@ jobs:
       run: cd .maven && ./maven-publish.sh
       
     - name: Upload Artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: full-repo-artifact-${{ github.ref_name }}
         path: ${{ github.workspace }}

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -284,7 +284,7 @@ jobs:
       # -----------------------------------------------------------------------
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: test-results-${{ github.run_number }}
           path: approov-service-retrofit/approov-service/build/reports/tests/

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1,0 +1,291 @@
+name: Build and Test
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    env:
+      WORKSPACE: "${{ github.workspace }}"
+      GIT_BRANCH: "${{ github.ref }}"
+      CURRENT_TAG: "${{ github.ref_name }}"
+      # Worker endpoints: consumed from GitHub organisation variables first.
+      # If the org variable is not set the value is an empty string; the probe
+      # step below falls back to the same hardcoded defaults that are baked into
+      # the mini-sdk (MiniAttesterConfig / Approov.m), keeping them in sync.
+      # Worker management (create / redeploy) logic is centralized in the
+      # core-service-layers-testing script, but invoked here when needed.
+      TESTING_REPLY_URL: ${{ vars.TESTING_REPLY_URL }}
+      TESTING_REPLY_URL_UNPROTECTED: ${{ vars.TESTING_REPLY_URL_UNPROTECTED }}
+      # Required for the redeploy script invocation on failure
+      CLOUDFLARE_API_TOKEN_WORKERS_DEV: ${{ secrets.CLOUDFLARE_API_TOKEN_WORKERS_DEV }}
+      CLOUDFLARE_ACCOUNT_ID_WORKERS_DEV: ${{ secrets.CLOUDFLARE_ACCOUNT_ID_WORKERS_DEV }}
+
+    steps:
+      # -----------------------------------------------------------------------
+      # 1. Checkout this repository
+      # -----------------------------------------------------------------------
+      - name: Set up Git
+        run: git config --global --add safe.directory '*'
+
+      - name: Checkout approov-service-retrofit
+        uses: actions/checkout@v5
+        with:
+          path: approov-service-retrofit
+
+      # -----------------------------------------------------------------------
+      # 2. Clone core-service-layers-testing as a sibling directory
+      #    settings.gradle expects: ../core-service-layers-testing/...
+      #    so both repos must sit under the same parent ($GITHUB_WORKSPACE).
+      # -----------------------------------------------------------------------
+      - name: Checkout core-service-layers-testing
+        uses: actions/checkout@v5
+        with:
+          repository: approov/core-service-layers-testing
+          token: ${{ secrets.CORE_SERVICE_LAYERS_TESTING_PAT }}
+          path: core-service-layers-testing
+
+      # -----------------------------------------------------------------------
+      # 3. Verify worker endpoints (with auto-redeploy)
+      #
+      #    URLs are resolved with the following precedence (mirrors the mini-sdk
+      #    fallback logic in MiniAttesterConfig / Approov.m):
+      #      1. GitHub org variable  (TESTING_REPLY_URL / _UNPROTECTED)
+      #      2. Mini-SDK hardcoded defaults (replay.ivol.workers.dev / ...)
+      #
+      #    If the workers are unavailable, this step invokes the management
+      #    script in core-service-layers-testing to redeploy them.
+      # -----------------------------------------------------------------------
+      - name: Verify worker endpoints
+        run: |
+          # ── URL resolution ──────────────────────────────────────────────────
+          PROTECTED_URL="${TESTING_REPLY_URL:-https://replay.ivol.workers.dev}"
+          UNPROTECTED_URL="${TESTING_REPLY_URL_UNPROTECTED:-https://replay-unprotected.ivol.workers.dev}"
+          
+          echo "TESTING_REPLY_URL=$PROTECTED_URL"       >> "$GITHUB_ENV"
+          echo "TESTING_REPLY_URL_UNPROTECTED=$UNPROTECTED_URL" >> "$GITHUB_ENV"
+
+          # ── Probe function ──────────────────────────────────────────────────
+          probe_worker() {
+            local url="$1"
+            curl --silent --show-error --fail --max-time 10 \
+              -X POST "$url" \
+              -H "Content-Type: application/json" \
+              -d '{"check":"probe"}' | grep -q '"body"'
+          }
+
+          echo "==> Probing workers..."
+          if probe_worker "$PROTECTED_URL" && probe_worker "$UNPROTECTED_URL"; then
+            echo "    All workers are healthy."
+            exit 0
+          fi
+
+          echo "    WARNING: One or more workers are down. Attempting redeploy..."
+          
+          # ── Invoke redeploy script ──────────────────────────────────────────
+          # The script is in the sibling directory cloned in Step 2.
+          # It uses the CLOUDFLARE_* env variables defined at the job level.
+          ./core-service-layers-testing/cloudflare-workers/redeploy-workers.sh
+
+          echo "==> Verifying after redeploy..."
+          # Try up to 3 times with a 5s delay between attempts
+          for i in {1..3}; do
+            if probe_worker "$PROTECTED_URL" && probe_worker "$UNPROTECTED_URL"; then
+              echo "    Workers successfully restored."
+              exit 0
+            fi
+            echo "    Waiting for propagation (attempt $i/3)..."
+            sleep 5
+          done
+
+          echo "ERROR: Workers are still unreachable after redeployment effort."
+          exit 1
+
+      # -----------------------------------------------------------------------
+      # 4. Java / Android toolchain setup
+      # -----------------------------------------------------------------------
+      - name: Set Up Java
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+
+      - name: Install Android SDK command-line tools
+        run: |
+          sudo apt-get update -q
+          sudo apt-get install -y -q unzip curl
+          mkdir -p "$ANDROID_HOME/cmdline-tools"
+          curl -o android-sdk.zip \
+            https://dl.google.com/android/repository/commandlinetools-linux-9123335_latest.zip
+          unzip -q android-sdk.zip -d "$ANDROID_HOME/cmdline-tools"
+          mv "$ANDROID_HOME/cmdline-tools/cmdline-tools" "$ANDROID_HOME/cmdline-tools/tools"
+          rm android-sdk.zip
+          echo "ANDROID_HOME=$ANDROID_HOME" >> "$GITHUB_ENV"
+          echo "$ANDROID_HOME/cmdline-tools/tools/bin:$ANDROID_HOME/platform-tools:$ANDROID_HOME/emulator" >> "$GITHUB_PATH"
+
+      - name: Accept Android SDK licenses
+        run: yes | sdkmanager --licenses || true
+
+      - name: Install required Android SDK packages
+        run: |
+          sdkmanager "platform-tools" "platforms;android-34" "build-tools;34.0.0"
+
+      # -----------------------------------------------------------------------
+      # 5. Build and run tests
+      #    Gradle is invoked from inside the checked-out service directory.
+      #    The mini-sdk is already available via the sibling path wired into
+      #    settings.gradle — no extra configuration needed here.
+      # -----------------------------------------------------------------------
+      - name: Build AAR
+        working-directory: approov-service-retrofit
+        run: ./gradlew assembleRelease
+
+      - name: Run unit tests
+        working-directory: approov-service-retrofit
+        env:
+          TESTING_REPLY_URL: ${{ env.TESTING_REPLY_URL }}
+          TESTING_REPLY_URL_UNPROTECTED: ${{ env.TESTING_REPLY_URL_UNPROTECTED }}
+        run: ./gradlew test
+
+      # -----------------------------------------------------------------------
+      # 6. Print test summary to the console and to the Actions Job Summary
+      #    Parses every JUnit XML produced by Gradle and emits:
+      #      • a formatted table in the step log
+      #      • a markdown table in the Job Summary (Actions UI → Summary tab)
+      # -----------------------------------------------------------------------
+      - name: Print test summary
+        if: always()
+        working-directory: approov-service-retrofit
+        run: |
+          python3 - <<'EOF'
+          import os, sys, glob, xml.etree.ElementTree as ET
+          from collections import defaultdict
+
+          PASS  = "\u2705"
+          FAIL  = "\u274c"
+          SKIP  = "\u23ed\ufe0f"
+          ERROR = "\u26a0\ufe0f"
+
+          results_root = "approov-service/build/test-results"
+          xml_files = sorted(glob.glob(f"{results_root}/**/*.xml", recursive=True))
+
+          if not xml_files:
+              print("No test-result XML files found.")
+              sys.exit(0)
+
+          # Group suites by variant directory name (testDebugUnitTest, etc.)
+          by_variant = defaultdict(list)
+          for path in xml_files:
+              variant = os.path.basename(os.path.dirname(path))
+              try:
+                  root = ET.parse(path).getroot()
+              except ET.ParseError:
+                  continue
+              suite = {
+                  "name":     root.get("name", os.path.basename(path)),
+                  "tests":    int(root.get("tests",    0)),
+                  "failures": int(root.get("failures", 0)),
+                  "errors":   int(root.get("errors",   0)),
+                  "skipped":  int(root.get("skipped",  0)),
+                  "time":     float(root.get("time",   0)),
+                  "cases":    [],
+              }
+              for tc in root.findall("testcase"):
+                  status = PASS
+                  detail = ""
+                  if tc.find("failure") is not None:
+                      status = FAIL
+                      detail = (tc.find("failure").get("message") or "").split("\n")[0][:120]
+                  elif tc.find("error") is not None:
+                      status = ERROR
+                      detail = (tc.find("error").get("message") or "").split("\n")[0][:120]
+                  elif tc.find("skipped") is not None:
+                      status = SKIP
+                  suite["cases"].append({
+                      "name":   tc.get("name", "?"),
+                      "time":   float(tc.get("time", 0)),
+                      "status": status,
+                      "detail": detail,
+                  })
+              by_variant[variant].append(suite)
+
+          # ── Console output ──────────────────────────────────────────────────
+          overall_ok = True
+          for variant, suites in sorted(by_variant.items()):
+              total_t = sum(s["tests"] for s in suites)
+              total_f = sum(s["failures"] + s["errors"] for s in suites)
+              total_s = sum(s["skipped"] for s in suites)
+              total_p = total_t - total_f - total_s
+              icon = PASS if total_f == 0 else FAIL
+              if total_f > 0:
+                  overall_ok = False
+              print()
+              print(f"{'='*70}")
+              print(f"  {icon}  {variant}  |  {total_p}/{total_t} passed  "
+                    f"|  {total_f} failed  |  {total_s} skipped")
+              print(f"{'='*70}")
+              for suite in suites:
+                  short = suite["name"].split(".")[-1]
+                  p = suite["tests"] - suite["failures"] - suite["errors"] - suite["skipped"]
+                  f = suite["failures"] + suite["errors"]
+                  print(f"  {PASS if f==0 else FAIL}  {short:<55} {p}/{suite['tests']}  ({suite['time']:.2f}s)")
+                  for case in suite["cases"]:
+                      if case["status"] != PASS:
+                          print(f"       {case['status']}  {case['name']}")
+                          if case["detail"]:
+                              print(f"          {case['detail']}")
+          print()
+
+          # ── GitHub Job Summary (markdown) ───────────────────────────────────
+          summary_path = os.environ.get("GITHUB_STEP_SUMMARY", "")
+          if not summary_path:
+              sys.exit(0 if overall_ok else 1)
+
+          with open(summary_path, "a") as md:
+              md.write("## \U0001f9ea Unit Test Results\n\n")
+              for variant, suites in sorted(by_variant.items()):
+                  total_t = sum(s["tests"] for s in suites)
+                  total_f = sum(s["failures"] + s["errors"] for s in suites)
+                  total_s = sum(s["skipped"] for s in suites)
+                  total_p = total_t - total_f - total_s
+                  badge = "\U0001f7e2 PASSED" if total_f == 0 else "\U0001f534 FAILED"
+                  md.write(f"### {variant} &nbsp; {badge}\n\n")
+                  md.write(f"> **{total_p} passed** &nbsp;|&nbsp; "
+                           f"**{total_f} failed** &nbsp;|&nbsp; "
+                           f"**{total_s} skipped** &nbsp;|&nbsp; "
+                           f"**{total_t} total**\n\n")
+                  md.write("| Status | Test suite | Tests | Failed | Skipped | Time |\n")
+                  md.write("|--------|------------|------:|-------:|--------:|-----:|\n")
+                  for suite in suites:
+                      short = suite["name"].split(".")[-1]
+                      f = suite["failures"] + suite["errors"]
+                      icon = "\U0001f7e2" if f == 0 else "\U0001f534"
+                      md.write(f"| {icon} | `{short}` | {suite['tests']} | {f} | {suite['skipped']} | {suite['time']:.2f}s |\n")
+                  # Expand failures inline
+                  failures = [c for s in suites for c in s["cases"] if c["status"] in (FAIL, ERROR)]
+                  if failures:
+                      md.write("\n<details><summary>Failed tests</summary>\n\n")
+                      for c in failures:
+                          md.write(f"- {c['status']} `{c['name']}`")
+                          if c["detail"]:
+                              md.write(f"  \n  > {c['detail']}")
+                          md.write("\n")
+                      md.write("\n</details>\n")
+                  md.write("\n")
+
+          sys.exit(0 if overall_ok else 1)
+          EOF
+
+      # -----------------------------------------------------------------------
+      # 7. Upload HTML reports as a downloadable artifact
+      # -----------------------------------------------------------------------
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v5
+        with:
+          name: test-results-${{ github.run_number }}
+          path: approov-service-retrofit/approov-service/build/reports/tests/
+          retention-days: 14

--- a/.github/workflows/build_only.yml
+++ b/.github/workflows/build_only.yml
@@ -23,10 +23,10 @@ jobs:
       run: git config --global --add safe.directory '*'
       
     - name: Checkout Repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Set Up Java
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
         distribution: 'temurin' # Use Eclipse Temurin distribution
         java-version: '21'      # Use Java 21 for Android builds

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on Keep a Changelog and this project adheres to Semantic Ver
 
 ### Added
 - Thread-safe failure mode caching for the interceptor path. When the platform SDK returns a failure status (`NO_NETWORK`, `POOR_NETWORK`, `MITM_DETECTED`, `NO_APPROOV_SERVICE`), the result is cached for 0.5 seconds. Subsequent requests within that window return the cached failure instantly, avoiding redundant ~1s SDK calls. Success is never cached.
+- Added `ApproovService.setFailureCacheTTL()` to customize the caching duration of failure statuses.
 - Added `ApproovService.isInitialized()` to expose the service-layer initialization state.
 - Integrated a localized testing framework for comprehensive service layer verification.
 - Added extensive test coverage for core service flows, including initialization, token management, and request mutation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on Keep a Changelog and this project adheres to Semantic Ver
 
 ### Added
 - Thread-safe failure mode caching for the interceptor path. When the platform SDK returns a failure status (`NO_NETWORK`, `POOR_NETWORK`, `MITM_DETECTED`, `NO_APPROOV_SERVICE`), the result is cached for 0.5 seconds. Subsequent requests within that window return the cached failure instantly, avoiding redundant ~1s SDK calls. Success is never cached.
-- Added `ApproovService.setFailureCacheTTL()` to customize the caching duration of failure statuses.
+- Added `ApproovService.setFailureCacheTtlMs()` to customize the caching duration of failure statuses in milliseconds.
 - Added `ApproovService.isInitialized()` to expose the service-layer initialization state.
 - Integrated a localized testing framework for comprehensive service layer verification.
 - Added extensive test coverage for core service flows, including initialization, token management, and request mutation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ The format is based on Keep a Changelog and this project adheres to Semantic Ver
 
 ### Changed
 - Initializing with an empty config string now keeps the service layer initialized while forwarding requests without Approov processing.
-- Initializing first with an empty config string and later with a valid non-empty config string now enables Approov at runtime instead of being rejected as a different-configuration initialization.
+- Initializing first with an empty config string and later with a valid non-empty config string now enables Approov for newly obtained Retrofit instances instead of being rejected as a different-configuration initialization.
 - Tightened the initialization guard so only actual `reinit...` comments bypass same-config enforcement.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this package will be documented in this file.
 The format is based on Keep a Changelog and this project adheres to Semantic Versioning.
 
 
+## [3.5.6] - 2026-04-21
+
+### Added
+- Thread-safe failure mode caching for the interceptor path. When the platform SDK returns a failure status (`NO_NETWORK`, `POOR_NETWORK`, `MITM_DETECTED`, `NO_APPROOV_SERVICE`), the result is cached for 0.5 seconds. Subsequent requests within that window return the cached failure instantly, avoiding redundant ~1s SDK calls. Success is never cached.
+- Added `ApproovService.isInitialized()` to expose the service-layer initialization state.
+- Integrated a localized testing framework for comprehensive service layer verification.
+- Added extensive test coverage for core service flows, including initialization, token management, and request mutation.
+
+### Changed
+- Initializing with an empty config string now keeps the service layer initialized while forwarding requests without Approov processing.
+- Initializing first with an empty config string and later with a valid non-empty config string now enables Approov at runtime instead of being rejected as a different-configuration initialization.
+- Tightened the initialization guard so only actual `reinit...` comments bypass same-config enforcement.
+
+### Fixed
+- Added explicit cross-service-layer initialization handling so a benign same-config already-initialized native SDK outcome is tolerated, while real different-configuration failures still surface as initialization errors.
+- Updated the build manifest to support flexible dependency resolution for verification suites.
+
 ## [3.5.5] - 2026-03-25
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,4 +40,4 @@ The format is based on Keep a Changelog and this project adheres to Semantic Ver
 ### Deprecated
 - ApproovInterceptorExtensions in favor of ApproovServiceMutator.
 - setProceedOnNetworkFail() and getProceedOnNetworkFail() in favor of setServiceMutator.
-- prefetch() is now automatically called when the service is initialized.
+- prefetch() is obsolete and is now a no-op. The underlying Approov SDK manages prefetching automatically.

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -187,6 +187,19 @@ void setUseApproovStatusIfNoToken(boolean shouldUse)
 fun setUseApproovStatusIfNoToken(shouldUse: Boolean)
 ```
 
+## setFailureCacheTTL
+Sets the time-to-live (in seconds) for caching Approov failure statuses (such as `NO_NETWORK`, `MITM_DETECTED`, etc.) during token fetches. The default TTL is 0.5 seconds. When the service is in a sustained failure state, caching the failure avoids redundant and potentially blocking calls to the native SDK for rapidly fired concurrent requests.
+
+**Java:**
+```Java
+void setFailureCacheTTL(double ttl)
+```
+
+**Kotlin:**
+```kotlin
+fun setFailureCacheTTL(ttl: Double)
+```
+
 ## setDevKey
 [Sets a development key](https://approov.io/docs/latest/approov-usage-documentation/#using-a-development-key) in order to force an app to be passed. This can be used if the app has to be resigned in a test environment and would thus fail attestation otherwise.
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -32,7 +32,7 @@ fun initialize(context: Context, config: String)
 
 The [application context](https://developer.android.com/reference/android/content/Context#getApplicationContext()) must be provided using the `context` parameter.
 
-It is possible to pass an empty `config` string to indicate that no initialization of the underlying native Approov SDK is required. This initializes the service layer in a bypass mode, allowing you to obtain a standard, non-Approov protected Retrofit client. If you attempt to use any direct native Approov SDK functions (such as `fetchToken` or `precheck`) while bypassed, an `ApproovException` will be thrown. You may later call `initialize` again with a valid `config` string to enable full Approov protection from that point onward.
+It is possible to pass an empty `config` string to indicate that no initialization of the underlying native Approov SDK is required. This initializes the service layer in a bypass mode, allowing you to obtain a standard, non-Approov protected Retrofit client. If you attempt to use any direct native Approov SDK functions (such as `fetchToken` or `precheck`) while bypassed, an `ApproovException` will be thrown. You may later call `initialize` again with a valid `config` string to enable Approov protection for Retrofit instances obtained after that point. Retrofit instances obtained while bypassed remain standard, non-Approov protected clients and should be discarded if protection is later enabled.
 
 An alternative initialization function allows to provide further options in the `comment` parameter. Please refer to the [Approov SDK documentation](https://approov.io/docs/latest/approov-direct-sdk-integration/#sdk-initialization-options) for details.
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -32,7 +32,7 @@ fun initialize(context: Context, config: String)
 
 The [application context](https://developer.android.com/reference/android/content/Context#getApplicationContext()) must be provided using the `context` parameter.
 
-It is possible to pass an empty `config` string to indicate that no initialization is required. Only do this if you are also using a different Approov service layer in your app (which will use the same underlying Approov SDK) and this will have been initialized first.
+It is possible to pass an empty `config` string to indicate that no initialization of the underlying native Approov SDK is required. This initializes the service layer in a bypass mode, allowing you to obtain a standard, non-Approov protected Retrofit client. If you attempt to use any direct native Approov SDK functions (such as `fetchToken` or `precheck`) while bypassed, an `ApproovException` will be thrown. You may later call `initialize` again with a valid `config` string to enable full Approov protection from that point onward.
 
 An alternative initialization function allows to provide further options in the `comment` parameter. Please refer to the [Approov SDK documentation](https://approov.io/docs/latest/approov-direct-sdk-integration/#sdk-initialization-options) for details.
 
@@ -44,6 +44,32 @@ void initialize(Context context, String config, String comment)
 **Kotlin:**
 ```kotlin
 fun initialize(context: Context, config: String, comment: String)
+```
+
+## isInitialized
+Indicates whether the Approov service layer has been initialized.
+
+**Java:**
+```Java
+boolean isInitialized()
+```
+
+**Kotlin:**
+```kotlin
+fun isInitialized(): Boolean
+```
+
+## isApproovEnabled
+Indicates whether the underlying native Approov SDK is enabled and active. If the service layer was initialized with an empty configuration string, this will return `false`.
+
+**Java:**
+```Java
+boolean isApproovEnabled()
+```
+
+**Kotlin:**
+```kotlin
+fun isApproovEnabled(): Boolean
 ```
 
 ## setApproovInterceptorExtensions

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -281,9 +281,7 @@ fun removeExclusionURLRegex(urlRegex: String)
 ```
 
 ## prefetch
-Allows an Approov fetch operation to be performed as early as possible. This permits a token or secure strings to be available while an application might be loading resources or is awaiting user input. Since the initial fetch is the most expensive the prefetch can hide the most latency.
-
-**DEPRECATED**: This method is now automatically called when the service is initialized.
+**OBSOLETE**: This method is obsolete and is now a no-op. The underlying Approov SDK manages prefetching automatically.
 
 **Java:**
 ```Java

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -187,17 +187,17 @@ void setUseApproovStatusIfNoToken(boolean shouldUse)
 fun setUseApproovStatusIfNoToken(shouldUse: Boolean)
 ```
 
-## setFailureCacheTTL
-Sets the time-to-live (in seconds) for caching Approov failure statuses (such as `NO_NETWORK`, `MITM_DETECTED`, etc.) during token fetches. The default TTL is 0.5 seconds. When the service is in a sustained failure state, caching the failure avoids redundant and potentially blocking calls to the native SDK for rapidly fired concurrent requests.
+## setFailureCacheTtlMs
+Sets the time-to-live (in milliseconds) for caching Approov failure statuses (such as `NO_NETWORK`, `MITM_DETECTED`, etc.) during interceptor token fetches. The default TTL is 500 milliseconds. When the service is in a sustained failure state, caching the failure avoids redundant and potentially blocking calls to the native SDK for rapidly fired concurrent requests.
 
 **Java:**
 ```Java
-void setFailureCacheTTL(double ttl)
+void setFailureCacheTtlMs(long ttlMs)
 ```
 
 **Kotlin:**
 ```kotlin
-fun setFailureCacheTTL(ttl: Double)
+fun setFailureCacheTtlMs(ttlMs: Long)
 ```
 
 ## setDevKey

--- a/approov-service/build.gradle
+++ b/approov-service/build.gradle
@@ -27,10 +27,19 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
     testOptions {
-        unitTests.returnDefaultValues = true
+        unitTests {
+            includeAndroidResources = false
+            returnDefaultValues = true
+        }
         unitTests.all {
             jvmArgs '-Dnet.bytebuddy.experimental=true'
         }
+    }
+}
+
+configurations {
+    testImplementation {
+        exclude group: 'io.approov', module: 'approov-android-sdk'
     }
 }
 
@@ -43,4 +52,13 @@ dependencies {
     implementation 'androidx.annotation:annotation-jvm:1.9.1'
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.mockito:mockito-inline:5.2.0'
+    if (findProject(':approov-sdk') != null) {
+        testImplementation project(':approov-sdk')
+    }
+    if (findProject(':test-support') != null) {
+        testImplementation project(':test-support')
+    }
+    testImplementation 'org.robolectric:robolectric:4.11.1'
+    testImplementation 'org.json:json:20231013'
+    testImplementation 'androidx.test:core:1.6.1'
 }

--- a/approov-service/build.gradle
+++ b/approov-service/build.gradle
@@ -58,7 +58,7 @@ if (findProject(':approov-sdk') != null) {
 dependencies {
     implementation 'com.squareup.okhttp3:okhttp:4.12.0'
     implementation 'io.approov:approov-android-sdk:3.5.3'
-    implementation 'org.bouncycastle:bcprov-jdk15to18:1.80'
+    implementation 'org.bouncycastle:bcprov-jdk15to18:1.84'
     implementation 'com.squareup.retrofit2:retrofit:2.11.0'
     implementation 'com.squareup.retrofit2:converter-gson:2.11.0'
     implementation 'androidx.annotation:annotation-jvm:1.9.1'

--- a/approov-service/build.gradle
+++ b/approov-service/build.gradle
@@ -35,11 +35,23 @@ android {
             jvmArgs '-Dnet.bytebuddy.experimental=true'
         }
     }
+
+    sourceSets {
+        test {
+            if (findProject(':test-support') == null) {
+                java {
+                    exclude '**/ApproovServiceMiniSdkTest.java'
+                }
+            }
+        }
+    }
 }
 
-configurations {
-    testImplementation {
-        exclude group: 'io.approov', module: 'approov-android-sdk'
+if (findProject(':approov-sdk') != null) {
+    configurations {
+        testImplementation {
+            exclude group: 'io.approov', module: 'approov-android-sdk'
+        }
     }
 }
 

--- a/approov-service/pom.xml
+++ b/approov-service/pom.xml
@@ -40,7 +40,7 @@
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcprov-jdk15to18</artifactId>
-      <version>1.80</version>
+      <version>1.84</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>

--- a/approov-service/src/main/AndroidManifest.xml
+++ b/approov-service/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="io.approov.service.retrofit">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
 </manifest>

--- a/approov-service/src/main/java/io/approov/service/retrofit/ApproovService.java
+++ b/approov-service/src/main/java/io/approov/service/retrofit/ApproovService.java
@@ -19,6 +19,7 @@ package io.approov.service.retrofit;
 
 import android.util.Log;
 import android.content.Context;
+import android.os.SystemClock;
 
 import com.criticalblue.approovsdk.Approov;
 
@@ -221,7 +222,7 @@ public class ApproovService {
      */
     static Approov.TokenFetchResult getCachedFailure() {
         synchronized (failureCacheLock) {
-            if (cachedFailureResult != null && (System.currentTimeMillis() - cachedFailureTimeMs) < FAILURE_CACHE_TTL_MS) {
+            if (cachedFailureResult != null && (SystemClock.elapsedRealtime() - cachedFailureTimeMs) < FAILURE_CACHE_TTL_MS) {
                 return cachedFailureResult;
             }
             // Cache miss or expired — clear and allow a fresh SDK call
@@ -242,7 +243,7 @@ public class ApproovService {
             case NO_APPROOV_SERVICE:
                 synchronized (failureCacheLock) {
                     cachedFailureResult = result;
-                    cachedFailureTimeMs = System.currentTimeMillis();
+                    cachedFailureTimeMs = SystemClock.elapsedRealtime();
                 }
                 break;
             default:

--- a/approov-service/src/main/java/io/approov/service/retrofit/ApproovService.java
+++ b/approov-service/src/main/java/io/approov/service/retrofit/ApproovService.java
@@ -216,14 +216,14 @@ public class ApproovService {
         return isInitialized && (configString != null) && !configString.isEmpty();
     }
 
-    /**
-     * Returns a cached failure result if one exists and hasn't expired.
-     * Returns null if no cache exists or it has expired (caller should fetch from SDK).
-     */
     static Approov.TokenFetchResult getCachedFailure() {
         synchronized (failureCacheLock) {
             if (cachedFailureResult != null && (SystemClock.elapsedRealtime() - cachedFailureTimeMs) < failureCacheTtlMs) {
+                Log.d(TAG, "using cached failure: " + cachedFailureResult.getStatus().toString());
                 return cachedFailureResult;
+            }
+            if (cachedFailureResult != null) {
+                Log.d(TAG, "failure cache expired");
             }
             // Cache miss or expired — clear and allow a fresh SDK call
             cachedFailureResult = null;
@@ -253,6 +253,7 @@ public class ApproovService {
                 synchronized (failureCacheLock) {
                     cachedFailureResult = result;
                     cachedFailureTimeMs = SystemClock.elapsedRealtime();
+                    Log.d(TAG, "caching failure: " + result.getStatus().toString());
                 }
                 break;
             default:

--- a/approov-service/src/main/java/io/approov/service/retrofit/ApproovService.java
+++ b/approov-service/src/main/java/io/approov/service/retrofit/ApproovService.java
@@ -119,7 +119,7 @@ public class ApproovService {
     private static final Object failureCacheLock = new Object();
     private static Approov.TokenFetchResult cachedFailureResult = null;
     private static long cachedFailureTimeMs = 0;
-    private static final long FAILURE_CACHE_TTL_MS = 500; // 0.5 seconds
+    private static long failureCacheTtlMs = 500; // 0.5 seconds default
 
     // map of cached Retrofit instances keyed by their unique builders
     private static Map<Retrofit.Builder, Retrofit> retrofitMap = new HashMap<>();
@@ -222,7 +222,7 @@ public class ApproovService {
      */
     static Approov.TokenFetchResult getCachedFailure() {
         synchronized (failureCacheLock) {
-            if (cachedFailureResult != null && (SystemClock.elapsedRealtime() - cachedFailureTimeMs) < FAILURE_CACHE_TTL_MS) {
+            if (cachedFailureResult != null && (SystemClock.elapsedRealtime() - cachedFailureTimeMs) < failureCacheTtlMs) {
                 return cachedFailureResult;
             }
             // Cache miss or expired — clear and allow a fresh SDK call
@@ -230,6 +230,15 @@ public class ApproovService {
             cachedFailureTimeMs = 0;
             return null;
         }
+    }
+
+    /**
+     * Sets the cache time-to-live for failure results (e.g. MITM_DETECTED).
+     * 
+     * @param ttlMs the time to live in milliseconds
+     */
+    public static void setFailureCacheTtlMs(long ttlMs) {
+        failureCacheTtlMs = ttlMs;
     }
 
     /**

--- a/approov-service/src/main/java/io/approov/service/retrofit/ApproovService.java
+++ b/approov-service/src/main/java/io/approov/service/retrofit/ApproovService.java
@@ -121,8 +121,10 @@ public class ApproovService {
     private static long cachedFailureTimeMs = 0;
     private static long failureCacheTtlMs = 500; // 0.5 seconds default
 
-    // Gate lock for the SDK fetch call. When the failure cache is empty, only ONE thread
-    // enters the SDK; all others wait on this lock and then re-check the cache.
+    // Gate lock for the SDK fetch call. When the service-layer failure cache is empty,
+    // only ONE thread enters the SDK; all others wait on this lock and then re-check
+    // the failure cache. This collapses concurrent failure storms that the SDK does
+    // not cache, while successful fetches use the SDK's own cache/fast path.
     // This is separate from failureCacheLock to avoid holding the cache lock during
     // the potentially long (~1-3s) SDK network call.
     private static final Object fetchGateLock = new Object();
@@ -256,7 +258,8 @@ public class ApproovService {
     }
 
     /**
-     * Caches a failure result. Only failure statuses are cached; success is never cached.
+     * Caches a failure result. Only failure statuses are cached by this service layer;
+     * success caching is handled by the SDK.
      */
     static void cacheFailureIfNeeded(Approov.TokenFetchResult result) {
         switch (result.getStatus()) {
@@ -271,7 +274,7 @@ public class ApproovService {
                 }
                 break;
             default:
-                // Success and other statuses are never cached
+                // Success and other statuses are not cached by this service layer.
                 break;
         }
     }
@@ -284,8 +287,9 @@ public class ApproovService {
      * wait, then re-check the cache. This collapses N concurrent SDK calls into 1 when
      * the platform is in a failure state (MITM, no network, etc.).
      * <p>
-     * On the happy path (SDK returns a valid token), no caching occurs and the gate
-     * is released immediately — subsequent threads each get their own unique token.
+     * On the happy path (SDK returns a valid token), this service layer does not
+     * cache the result. Subsequent threads still pass through the gate, but the SDK
+     * is expected to serve successful follow-up fetches from its own cache/fast path.
      *
      * @param url the URL to fetch the token for
      * @return the token fetch result (from cache or fresh SDK call)
@@ -297,7 +301,7 @@ public class ApproovService {
             return cached;
         }
 
-        // 2. Slow path — gate ensures only one thread calls the SDK
+        // 2. Slow path — gate ensures only one thread refreshes the failure state
         synchronized (fetchGateLock) {
             // Double-check: another thread may have populated the cache while we waited
             cached = getCachedFailure();
@@ -310,7 +314,7 @@ public class ApproovService {
             Log.d(TAG, "gate: fetching token for " + url);
             Approov.TokenFetchResult result = Approov.fetchApproovTokenAndWait(url);
 
-            // Cache only failures; success tokens are unique per-request
+            // Cache only failures here; success caching is handled inside the SDK.
             cacheFailureIfNeeded(result);
             return result;
         }
@@ -1203,7 +1207,7 @@ class ApproovTokenInterceptor implements Interceptor {
 
         // Fetch token using double-checked locking on the failure cache.
         // Fast path: cached failure returned immediately (no lock).
-        // Slow path: gate ensures only one thread calls the SDK; others wait and re-check.
+        // Slow path: gate ensures only one thread refreshes failure state; others wait and re-check.
         Approov.TokenFetchResult approovResults = ApproovService.fetchApproovTokenWithGate(url.toString());
 
         // provide information about the obtained token or error (note "approov token -check" can

--- a/approov-service/src/main/java/io/approov/service/retrofit/ApproovService.java
+++ b/approov-service/src/main/java/io/approov/service/retrofit/ApproovService.java
@@ -603,11 +603,12 @@ public class ApproovService {
      * Prefetches in the background to lower the effective latency of a subsequent token fetch or
      * secure string fetch by starting the operation earlier so the subsequent fetch may be able to
      * use cached data.
+     * <p>
+     * Note: This method is obsolete and is now a no-op. The underlying Approov SDK manages prefetching automatically.
      */
+    @Deprecated
     public static synchronized void prefetch() {
-        if (isInitialized)
-            // fetch an Approov token using a placeholder domain
-            Approov.fetchApproovToken(new PrefetchCallbackHandler(), "approov.io");
+        Log.w(TAG, "prefetch is no longer used and does nothing.");
     }
 
     /**
@@ -622,6 +623,10 @@ public class ApproovService {
      * @throws ApproovException if there was a problem
      */
     public static void precheck() throws ApproovException {
+        if (!isApproovEnabled()) {
+            Log.e(TAG, "precheck: SDK not initialized");
+            throw new ApproovException("precheck: SDK not initialized");
+        }
         // try and fetch a non-existent secure string in order to check for a rejection
         Approov.TokenFetchResult approovResults;
         try {
@@ -648,6 +653,10 @@ public class ApproovService {
      * @throws ApproovException if there was a problem
      */
     public static String getDeviceID() throws ApproovException {
+        if (!isApproovEnabled()) {
+            Log.e(TAG, "getDeviceID: SDK not initialized");
+            throw new ApproovException("getDeviceID: SDK not initialized");
+        }
         try {
             String deviceID = Approov.getDeviceID();
             Log.d(TAG, "getDeviceID: " + deviceID);
@@ -669,6 +678,10 @@ public class ApproovService {
      * @throws ApproovException if there was a problem
      */
     public static void setDataHashInToken(String data) throws ApproovException {
+        if (!isApproovEnabled()) {
+            Log.e(TAG, "setDataHashInToken: SDK not initialized");
+            throw new ApproovException("setDataHashInToken: SDK not initialized");
+        }
         try {
             Approov.setDataHashInToken(data);
             Log.d(TAG, "setDataHashInToken");
@@ -695,6 +708,10 @@ public class ApproovService {
      * @throws ApproovException if there was a problem
      */
     public static String fetchToken(String url) throws ApproovException {
+        if (!isApproovEnabled()) {
+            Log.e(TAG, "fetchToken: SDK not initialized");
+            throw new ApproovException("fetchToken: SDK not initialized");
+        }
         // fetch the Approov token
         Approov.TokenFetchResult approovResults;
         try {
@@ -747,6 +764,10 @@ public class ApproovService {
      * @throws ApproovException if there was a problem
      */
     public static String getAccountMessageSignature(String message) throws ApproovException {
+        if (!isApproovEnabled()) {
+            Log.e(TAG, "getAccountMessageSignature: SDK not initialized");
+            throw new ApproovException("getAccountMessageSignature: SDK not initialized");
+        }
         try {
             String signature = Approov.getAccountMessageSignature(message);
             Log.d(TAG, "getAccountMessageSignature");
@@ -780,6 +801,10 @@ public class ApproovService {
      * @throws ApproovException if there was a problem
      */
     public static String getInstallMessageSignature(String message) throws ApproovException {
+        if (!isApproovEnabled()) {
+            Log.e(TAG, "getInstallMessageSignature: SDK not initialized");
+            throw new ApproovException("getInstallMessageSignature: SDK not initialized");
+        }
         try {
             String signature = Approov.getInstallMessageSignature(message);
             Log.d(TAG, "getInstallMessageSignature");
@@ -812,6 +837,10 @@ public class ApproovService {
      * @throws ApproovException if there was a problem
      */
     public static String fetchSecureString(String key, String newDef) throws ApproovException {
+        if (!isApproovEnabled()) {
+            Log.e(TAG, "fetchSecureString: SDK not initialized");
+            throw new ApproovException("fetchSecureString: SDK not initialized");
+        }
         // determine the type of operation as the values themselves cannot be logged
         String type = "lookup";
         if (newDef != null)
@@ -847,6 +876,10 @@ public class ApproovService {
      * @throws ApproovException if there was a problem
      */
     public static String fetchCustomJWT(String payload) throws ApproovException {
+        if (!isApproovEnabled()) {
+            Log.e(TAG, "fetchCustomJWT: SDK not initialized");
+            throw new ApproovException("fetchCustomJWT: SDK not initialized");
+        }
         // fetch the custom JWT catching any exceptions the SDK might throw
         Approov.TokenFetchResult approovResults;
         try {

--- a/approov-service/src/main/java/io/approov/service/retrofit/ApproovService.java
+++ b/approov-service/src/main/java/io/approov/service/retrofit/ApproovService.java
@@ -211,7 +211,7 @@ public class ApproovService {
      *
      * @return true if Approov protection is enabled, false otherwise
      */
-    static synchronized boolean isApproovEnabled() {
+    public static synchronized boolean isApproovEnabled() {
         return isInitialized && (configString != null) && !configString.isEmpty();
     }
 

--- a/approov-service/src/main/java/io/approov/service/retrofit/ApproovService.java
+++ b/approov-service/src/main/java/io/approov/service/retrofit/ApproovService.java
@@ -112,6 +112,14 @@ public class ApproovService {
     // set of URL regexs that should be excluded from any Approov protection, mapped to the compiled Pattern
     private static Map<String, Pattern> exclusionURLRegexs = null;
 
+    // Cached failure result from the last Approov token fetch that returned a failure status.
+    // Protected by failureCacheLock for thread-safe access. This avoids redundant ~1s SDK calls
+    // when the platform is in a sustained failure state (e.g. no network, MITM detected).
+    private static final Object failureCacheLock = new Object();
+    private static Approov.TokenFetchResult cachedFailureResult = null;
+    private static long cachedFailureTimeMs = 0;
+    private static final long FAILURE_CACHE_TTL_MS = 500; // 0.5 seconds
+
     // map of cached Retrofit instances keyed by their unique builders
     private static Map<Retrofit.Builder, Retrofit> retrofitMap = new HashMap<>();
 
@@ -130,9 +138,10 @@ public class ApproovService {
      */
     public static synchronized void initialize(Context context, String config, String comment) {
         // check if the Approov SDK is already initialized
-        if (isInitialized && !comment.startsWith("reinit")) {
+        boolean allowEnableAfterEmptyInitialization = isInitialized && (configString != null) && configString.isEmpty() && !config.isEmpty();
+        if (isInitialized && !comment.startsWith("reinit") && !allowEnableAfterEmptyInitialization) {
             if (!config.equals(configString)) {
-                throw new IllegalStateException("ApproovService layer is already initialized");
+                throw new IllegalStateException("ApproovService layer is already initialized.");
             }
             Log.d(TAG, "Ignoring multiple ApproovService layer initializations with the same config");
         }
@@ -151,6 +160,10 @@ public class ApproovService {
             substitutionHeaders = new HashMap<>();
             substitutionQueryParams = new HashMap<>();
             exclusionURLRegexs = new HashMap<>();
+            synchronized (failureCacheLock) {
+                cachedFailureResult = null;
+                cachedFailureTimeMs = 0;
+            }
 
             // initialize the Approov SDK
             try {
@@ -160,12 +173,14 @@ public class ApproovService {
                 Log.e(TAG, "Approov initialization failed: " + e.getMessage());
                 throw e;
             } catch (IllegalStateException e) {
-                Log.e(TAG, "Approov already intialized: Ignoring native layer exception " + e.getMessage());
+                Log.e(TAG, "Approov initialization failed: " + e.getMessage());
+                throw e;
             }
             pinningInterceptor = new ApproovPinningInterceptor();
             isInitialized = true;
             configString = config;
-            Approov.setUserProperty("approov-service-retrofit");
+            if (!config.isEmpty())
+                Approov.setUserProperty("approov-service-retrofit");
         }
     }
 
@@ -178,6 +193,62 @@ public class ApproovService {
     public static void initialize(Context context, String config) {
         // default uses the empty comment string
         initialize(context, config, "");
+    }
+
+    /**
+     * Indicates whether the service layer has been initialized.
+     *
+     * @return true if the service layer has been initialized, false otherwise
+     */
+    public static synchronized boolean isInitialized() {
+        return isInitialized;
+    }
+
+    /**
+     * Indicates whether Approov protection is enabled for this service layer
+     * instance. If initialization used an empty config string then the layer is
+     * initialized but Approov protection is bypassed.
+     *
+     * @return true if Approov protection is enabled, false otherwise
+     */
+    static synchronized boolean isApproovEnabled() {
+        return isInitialized && (configString != null) && !configString.isEmpty();
+    }
+
+    /**
+     * Returns a cached failure result if one exists and hasn't expired.
+     * Returns null if no cache exists or it has expired (caller should fetch from SDK).
+     */
+    private static Approov.TokenFetchResult getCachedFailure() {
+        synchronized (failureCacheLock) {
+            if (cachedFailureResult != null && (System.currentTimeMillis() - cachedFailureTimeMs) < FAILURE_CACHE_TTL_MS) {
+                return cachedFailureResult;
+            }
+            // Cache miss or expired — clear and allow a fresh SDK call
+            cachedFailureResult = null;
+            cachedFailureTimeMs = 0;
+            return null;
+        }
+    }
+
+    /**
+     * Caches a failure result. Only failure statuses are cached; success is never cached.
+     */
+    private static void cacheFailureIfNeeded(Approov.TokenFetchResult result) {
+        switch (result.getStatus()) {
+            case NO_NETWORK:
+            case POOR_NETWORK:
+            case MITM_DETECTED:
+            case NO_APPROOV_SERVICE:
+                synchronized (failureCacheLock) {
+                    cachedFailureResult = result;
+                    cachedFailureTimeMs = System.currentTimeMillis();
+                }
+                break;
+            default:
+                // Success and other statuses are never cached
+                break;
+        }
     }
 
     /**
@@ -901,7 +972,7 @@ public class ApproovService {
         if (retrofit == null) {
             // build any required OkHttpClient on demand
             OkHttpClient okHttpClient;
-            if (isInitialized) {
+            if (isApproovEnabled()) {
                 // remove any existing ApproovTokenInterceptor from the builder
                 List<Interceptor> interceptors = okHttpBuilder.interceptors();
                 Iterator<Interceptor> iter = interceptors.iterator();
@@ -1013,8 +1084,19 @@ class ApproovTokenInterceptor implements Interceptor {
 
         okhttp3.HttpUrl url = request.url();
 
-        // request an Approov token for the request URL
-        Approov.TokenFetchResult approovResults = Approov.fetchApproovTokenAndWait(url.toString());
+        // Check for a cached failure before calling the platform SDK. This avoids redundant
+        // SDK calls when the platform is in a sustained failure state.
+        Approov.TokenFetchResult approovResults;
+        Approov.TokenFetchResult cached = getCachedFailure();
+        if (cached != null) {
+            approovResults = cached;
+            Log.d(TAG, "Using cached failure: " + cached.getStatus().toString());
+        } else {
+            // request an Approov token for the request URL
+            approovResults = Approov.fetchApproovTokenAndWait(url.toString());
+            // Cache the result if it is a failure
+            cacheFailureIfNeeded(approovResults);
+        }
 
         // provide information about the obtained token or error (note "approov token -check" can
         // be used to check the validity of the token and if you use token annotations they

--- a/approov-service/src/main/java/io/approov/service/retrofit/ApproovService.java
+++ b/approov-service/src/main/java/io/approov/service/retrofit/ApproovService.java
@@ -117,7 +117,6 @@ public class ApproovService {
     // Protected by failureCacheLock for thread-safe access. This avoids redundant ~1s SDK calls
     // when the platform is in a sustained failure state (e.g. no network, MITM detected).
     private static final Object failureCacheLock = new Object();
-    private static String cachedFailureKey = null;
     private static Approov.TokenFetchResult cachedFailureResult = null;
     private static long cachedFailureTimeMs = 0;
     private static long failureCacheTtlMs = 500; // 0.5 seconds default
@@ -163,7 +162,6 @@ public class ApproovService {
             substitutionQueryParams = new HashMap<>();
             exclusionURLRegexs = new HashMap<>();
             synchronized (failureCacheLock) {
-                cachedFailureKey = null;
                 cachedFailureResult = null;
                 cachedFailureTimeMs = 0;
             }
@@ -221,10 +219,9 @@ public class ApproovService {
         return isInitialized && (configString != null) && !configString.isEmpty();
     }
 
-    static Approov.TokenFetchResult getCachedFailure(String cacheKey) {
+    static Approov.TokenFetchResult getCachedFailure() {
         synchronized (failureCacheLock) {
             if (cachedFailureResult != null &&
-                    cacheKey.equals(cachedFailureKey) &&
                     (SystemClock.elapsedRealtime() - cachedFailureTimeMs) < failureCacheTtlMs) {
                 Log.d(TAG, "using cached failure: " + cachedFailureResult.getStatus().toString());
                 return cachedFailureResult;
@@ -233,7 +230,6 @@ public class ApproovService {
                 Log.d(TAG, "failure cache expired");
             }
             // Cache miss or expired — clear and allow a fresh SDK call
-            cachedFailureKey = null;
             cachedFailureResult = null;
             cachedFailureTimeMs = 0;
             return null;
@@ -248,7 +244,6 @@ public class ApproovService {
     public static void setFailureCacheTtlMs(long ttlMs) {
         synchronized (failureCacheLock) {
             failureCacheTtlMs = ttlMs;
-            cachedFailureKey = null;
             cachedFailureResult = null;
             cachedFailureTimeMs = 0;
         }
@@ -257,14 +252,13 @@ public class ApproovService {
     /**
      * Caches a failure result. Only failure statuses are cached; success is never cached.
      */
-    static void cacheFailureIfNeeded(String cacheKey, Approov.TokenFetchResult result) {
+    static void cacheFailureIfNeeded(Approov.TokenFetchResult result) {
         switch (result.getStatus()) {
             case NO_NETWORK:
             case POOR_NETWORK:
             case MITM_DETECTED:
             case NO_APPROOV_SERVICE:
                 synchronized (failureCacheLock) {
-                    cachedFailureKey = cacheKey;
                     cachedFailureResult = result;
                     cachedFailureTimeMs = SystemClock.elapsedRealtime();
                     Log.d(TAG, "caching failure: " + result.getStatus().toString());
@@ -1164,7 +1158,7 @@ class ApproovTokenInterceptor implements Interceptor {
         // Check for a cached failure before calling the platform SDK. This avoids redundant
         // SDK calls when the platform is in a sustained failure state.
         Approov.TokenFetchResult approovResults;
-        Approov.TokenFetchResult cached = ApproovService.getCachedFailure(url.toString());
+        Approov.TokenFetchResult cached = ApproovService.getCachedFailure();
         if (cached != null) {
             approovResults = cached;
             Log.d(TAG, "Using cached failure: " + cached.getStatus().toString());
@@ -1172,7 +1166,7 @@ class ApproovTokenInterceptor implements Interceptor {
             // request an Approov token for the request URL
             approovResults = Approov.fetchApproovTokenAndWait(url.toString());
             // Cache the result if it is a failure
-            ApproovService.cacheFailureIfNeeded(url.toString(), approovResults);
+            ApproovService.cacheFailureIfNeeded(approovResults);
         }
 
         // provide information about the obtained token or error (note "approov token -check" can

--- a/approov-service/src/main/java/io/approov/service/retrofit/ApproovService.java
+++ b/approov-service/src/main/java/io/approov/service/retrofit/ApproovService.java
@@ -121,6 +121,12 @@ public class ApproovService {
     private static long cachedFailureTimeMs = 0;
     private static long failureCacheTtlMs = 500; // 0.5 seconds default
 
+    // Gate lock for the SDK fetch call. When the failure cache is empty, only ONE thread
+    // enters the SDK; all others wait on this lock and then re-check the cache.
+    // This is separate from failureCacheLock to avoid holding the cache lock during
+    // the potentially long (~1-3s) SDK network call.
+    private static final Object fetchGateLock = new Object();
+
     // map of cached Retrofit instances keyed by their unique builders
     private static Map<Retrofit.Builder, Retrofit> retrofitMap = new HashMap<>();
 
@@ -267,6 +273,46 @@ public class ApproovService {
             default:
                 // Success and other statuses are never cached
                 break;
+        }
+    }
+
+    /**
+     * Fetches an Approov token using a double-checked locking pattern on the failure cache.
+     * <p>
+     * Fast path: if a valid cached failure exists, return it immediately (no lock).
+     * Slow path: acquire the fetch gate so only ONE thread calls the SDK. Other threads
+     * wait, then re-check the cache. This collapses N concurrent SDK calls into 1 when
+     * the platform is in a failure state (MITM, no network, etc.).
+     * <p>
+     * On the happy path (SDK returns a valid token), no caching occurs and the gate
+     * is released immediately — subsequent threads each get their own unique token.
+     *
+     * @param url the URL to fetch the token for
+     * @return the token fetch result (from cache or fresh SDK call)
+     */
+    static Approov.TokenFetchResult fetchApproovTokenWithGate(String url) {
+        // 1. Fast path — check cache without any lock
+        Approov.TokenFetchResult cached = getCachedFailure();
+        if (cached != null) {
+            return cached;
+        }
+
+        // 2. Slow path — gate ensures only one thread calls the SDK
+        synchronized (fetchGateLock) {
+            // Double-check: another thread may have populated the cache while we waited
+            cached = getCachedFailure();
+            if (cached != null) {
+                Log.d(TAG, "gate: another thread cached failure while waiting: " + cached.getStatus());
+                return cached;
+            }
+
+            // We are the elected thread — make the SDK call
+            Log.d(TAG, "gate: fetching token for " + url);
+            Approov.TokenFetchResult result = Approov.fetchApproovTokenAndWait(url);
+
+            // Cache only failures; success tokens are unique per-request
+            cacheFailureIfNeeded(result);
+            return result;
         }
     }
 
@@ -1155,19 +1201,10 @@ class ApproovTokenInterceptor implements Interceptor {
 
         okhttp3.HttpUrl url = request.url();
 
-        // Check for a cached failure before calling the platform SDK. This avoids redundant
-        // SDK calls when the platform is in a sustained failure state.
-        Approov.TokenFetchResult approovResults;
-        Approov.TokenFetchResult cached = ApproovService.getCachedFailure();
-        if (cached != null) {
-            approovResults = cached;
-            Log.d(TAG, "Using cached failure: " + cached.getStatus().toString());
-        } else {
-            // request an Approov token for the request URL
-            approovResults = Approov.fetchApproovTokenAndWait(url.toString());
-            // Cache the result if it is a failure
-            ApproovService.cacheFailureIfNeeded(approovResults);
-        }
+        // Fetch token using double-checked locking on the failure cache.
+        // Fast path: cached failure returned immediately (no lock).
+        // Slow path: gate ensures only one thread calls the SDK; others wait and re-check.
+        Approov.TokenFetchResult approovResults = ApproovService.fetchApproovTokenWithGate(url.toString());
 
         // provide information about the obtained token or error (note "approov token -check" can
         // be used to check the validity of the token and if you use token annotations they

--- a/approov-service/src/main/java/io/approov/service/retrofit/ApproovService.java
+++ b/approov-service/src/main/java/io/approov/service/retrofit/ApproovService.java
@@ -219,7 +219,7 @@ public class ApproovService {
      * Returns a cached failure result if one exists and hasn't expired.
      * Returns null if no cache exists or it has expired (caller should fetch from SDK).
      */
-    private static Approov.TokenFetchResult getCachedFailure() {
+    static Approov.TokenFetchResult getCachedFailure() {
         synchronized (failureCacheLock) {
             if (cachedFailureResult != null && (System.currentTimeMillis() - cachedFailureTimeMs) < FAILURE_CACHE_TTL_MS) {
                 return cachedFailureResult;
@@ -234,7 +234,7 @@ public class ApproovService {
     /**
      * Caches a failure result. Only failure statuses are cached; success is never cached.
      */
-    private static void cacheFailureIfNeeded(Approov.TokenFetchResult result) {
+    static void cacheFailureIfNeeded(Approov.TokenFetchResult result) {
         switch (result.getStatus()) {
             case NO_NETWORK:
             case POOR_NETWORK:
@@ -1087,7 +1087,7 @@ class ApproovTokenInterceptor implements Interceptor {
         // Check for a cached failure before calling the platform SDK. This avoids redundant
         // SDK calls when the platform is in a sustained failure state.
         Approov.TokenFetchResult approovResults;
-        Approov.TokenFetchResult cached = getCachedFailure();
+        Approov.TokenFetchResult cached = ApproovService.getCachedFailure();
         if (cached != null) {
             approovResults = cached;
             Log.d(TAG, "Using cached failure: " + cached.getStatus().toString());
@@ -1095,7 +1095,7 @@ class ApproovTokenInterceptor implements Interceptor {
             // request an Approov token for the request URL
             approovResults = Approov.fetchApproovTokenAndWait(url.toString());
             // Cache the result if it is a failure
-            cacheFailureIfNeeded(approovResults);
+            ApproovService.cacheFailureIfNeeded(approovResults);
         }
 
         // provide information about the obtained token or error (note "approov token -check" can

--- a/approov-service/src/main/java/io/approov/service/retrofit/ApproovService.java
+++ b/approov-service/src/main/java/io/approov/service/retrofit/ApproovService.java
@@ -117,6 +117,7 @@ public class ApproovService {
     // Protected by failureCacheLock for thread-safe access. This avoids redundant ~1s SDK calls
     // when the platform is in a sustained failure state (e.g. no network, MITM detected).
     private static final Object failureCacheLock = new Object();
+    private static String cachedFailureKey = null;
     private static Approov.TokenFetchResult cachedFailureResult = null;
     private static long cachedFailureTimeMs = 0;
     private static long failureCacheTtlMs = 500; // 0.5 seconds default
@@ -162,6 +163,7 @@ public class ApproovService {
             substitutionQueryParams = new HashMap<>();
             exclusionURLRegexs = new HashMap<>();
             synchronized (failureCacheLock) {
+                cachedFailureKey = null;
                 cachedFailureResult = null;
                 cachedFailureTimeMs = 0;
             }
@@ -177,7 +179,10 @@ public class ApproovService {
                 Log.e(TAG, "Approov initialization failed: " + e.getMessage());
                 throw e;
             }
-            pinningInterceptor = new ApproovPinningInterceptor();
+            if (!config.isEmpty())
+                pinningInterceptor = new ApproovPinningInterceptor();
+            else
+                pinningInterceptor = null;
             isInitialized = true;
             configString = config;
             if (!config.isEmpty())
@@ -216,9 +221,11 @@ public class ApproovService {
         return isInitialized && (configString != null) && !configString.isEmpty();
     }
 
-    static Approov.TokenFetchResult getCachedFailure() {
+    static Approov.TokenFetchResult getCachedFailure(String cacheKey) {
         synchronized (failureCacheLock) {
-            if (cachedFailureResult != null && (SystemClock.elapsedRealtime() - cachedFailureTimeMs) < failureCacheTtlMs) {
+            if (cachedFailureResult != null &&
+                    cacheKey.equals(cachedFailureKey) &&
+                    (SystemClock.elapsedRealtime() - cachedFailureTimeMs) < failureCacheTtlMs) {
                 Log.d(TAG, "using cached failure: " + cachedFailureResult.getStatus().toString());
                 return cachedFailureResult;
             }
@@ -226,6 +233,7 @@ public class ApproovService {
                 Log.d(TAG, "failure cache expired");
             }
             // Cache miss or expired — clear and allow a fresh SDK call
+            cachedFailureKey = null;
             cachedFailureResult = null;
             cachedFailureTimeMs = 0;
             return null;
@@ -238,19 +246,25 @@ public class ApproovService {
      * @param ttlMs the time to live in milliseconds
      */
     public static void setFailureCacheTtlMs(long ttlMs) {
-        failureCacheTtlMs = ttlMs;
+        synchronized (failureCacheLock) {
+            failureCacheTtlMs = ttlMs;
+            cachedFailureKey = null;
+            cachedFailureResult = null;
+            cachedFailureTimeMs = 0;
+        }
     }
 
     /**
      * Caches a failure result. Only failure statuses are cached; success is never cached.
      */
-    static void cacheFailureIfNeeded(Approov.TokenFetchResult result) {
+    static void cacheFailureIfNeeded(String cacheKey, Approov.TokenFetchResult result) {
         switch (result.getStatus()) {
             case NO_NETWORK:
             case POOR_NETWORK:
             case MITM_DETECTED:
             case NO_APPROOV_SERVICE:
                 synchronized (failureCacheLock) {
+                    cachedFailureKey = cacheKey;
                     cachedFailureResult = result;
                     cachedFailureTimeMs = SystemClock.elapsedRealtime();
                     Log.d(TAG, "caching failure: " + result.getStatus().toString());
@@ -330,6 +344,10 @@ public class ApproovService {
      * @throws ApproovException if there was a problem
      */
     public static synchronized void setDevKey(String devKey) throws ApproovException {
+        if (!isApproovEnabled()) {
+            Log.e(TAG, "setDevKey: SDK not initialized");
+            throw new ApproovException("setDevKey: SDK not initialized");
+        }
         try {
             Approov.setDevKey(devKey);
             Log.d(TAG, "setDevKey");
@@ -918,6 +936,10 @@ public class ApproovService {
      * @return String ARC from last attestation request or empty string if network unavailable
      */
     public static String getLastARC() {
+        if (!isApproovEnabled()) {
+            Log.e(TAG, "getLastARC: SDK not initialized");
+            return "";
+        }
         // Get the dynamic pins from Approov
         Map<String, List<String>> approovPins = Approov.getPins("public-key-sha256");
         if (approovPins == null || approovPins.isEmpty()) {
@@ -965,6 +987,10 @@ public class ApproovService {
      * @throws ApproovException if the attrs parameter is invalid or the SDK is not initialized
      */
     public static void setInstallAttrsInToken(String attrs) throws ApproovException {
+        if (!isApproovEnabled()) {
+            Log.e(TAG, "setInstallAttrsInToken: SDK not initialized");
+            throw new ApproovException("setInstallAttrsInToken: SDK not initialized");
+        }
         try {
             Approov.setInstallAttrsInToken(attrs);
             Log.d(TAG, "setInstallAttrsInToken");
@@ -1115,6 +1141,10 @@ class ApproovTokenInterceptor implements Interceptor {
     public Response intercept(Chain chain) throws IOException {
 
         Request request = chain.request();
+        if (!ApproovService.isApproovEnabled()) {
+            return chain.proceed(request);
+        }
+
         // cache the mutator for the duration of the interceptor to make sure
         // it is not changed mid-flight
         ApproovServiceMutator mutator = ApproovService.getServiceMutator();
@@ -1134,7 +1164,7 @@ class ApproovTokenInterceptor implements Interceptor {
         // Check for a cached failure before calling the platform SDK. This avoids redundant
         // SDK calls when the platform is in a sustained failure state.
         Approov.TokenFetchResult approovResults;
-        Approov.TokenFetchResult cached = ApproovService.getCachedFailure();
+        Approov.TokenFetchResult cached = ApproovService.getCachedFailure(url.toString());
         if (cached != null) {
             approovResults = cached;
             Log.d(TAG, "Using cached failure: " + cached.getStatus().toString());
@@ -1142,7 +1172,7 @@ class ApproovTokenInterceptor implements Interceptor {
             // request an Approov token for the request URL
             approovResults = Approov.fetchApproovTokenAndWait(url.toString());
             // Cache the result if it is a failure
-            ApproovService.cacheFailureIfNeeded(approovResults);
+            ApproovService.cacheFailureIfNeeded(url.toString(), approovResults);
         }
 
         // provide information about the obtained token or error (note "approov token -check" can
@@ -1379,6 +1409,10 @@ class ApproovPinningInterceptor implements Interceptor {
     @Override
     public Response intercept(Chain chain) throws IOException {
         Request request = chain.request();
+        if (!ApproovService.isApproovEnabled()) {
+            return chain.proceed(request);
+        }
+
         // first check if we are to proceed with any pinning processing
         if (!ApproovService.getServiceMutator().handlePinningShouldProcessRequest(request)) {
             // we are not to proceed with any pinning processing so just continue

--- a/approov-service/src/main/java/io/approov/service/retrofit/ApproovService.java
+++ b/approov-service/src/main/java/io/approov/service/retrofit/ApproovService.java
@@ -1030,8 +1030,11 @@ public class ApproovService {
                 okHttpClient = okHttpBuilder.addInterceptor(tokenInterceptor)
                                 .addNetworkInterceptor(pinningInterceptor).build();
             } else {
-                // if the Approov SDK could not be initialized then we can't pin or add Approov tokens
-                Log.e(TAG, "Cannot build Approov OkHttpClient as not initialized");
+                if (isInitialized()) {
+                    Log.i(TAG, "Building basic OkHttpClient (Approov bypass mode)");
+                } else {
+                    Log.e(TAG, "Cannot build Approov OkHttpClient as not initialized");
+                }
                 if (okHttpBuilder == null)
                     okHttpBuilder = new OkHttpClient.Builder();
                 okHttpClient = okHttpBuilder.build();

--- a/approov-service/src/test/java/io/approov/service/retrofit/ApproovServiceContractTest.java
+++ b/approov-service/src/test/java/io/approov/service/retrofit/ApproovServiceContractTest.java
@@ -182,12 +182,15 @@ public class ApproovServiceContractTest {
             Interceptor.Chain firstChain = ApproovTestSupport.interceptorChain(firstRequest);
             Interceptor.Chain secondChain = ApproovTestSupport.interceptorChain(secondRequest);
 
-            // First request populates the global failure cache
-            interceptor.intercept(firstChain).close();
+            // First request populates the global failure cache (throws because
+            // NO_NETWORK is a hard failure by default)
+            assertThrows(ApproovNetworkException.class,
+                    () -> interceptor.intercept(firstChain));
 
             // Second request to a different URL should use the cached failure
             // without calling the SDK again (NO_NETWORK is device-wide)
-            interceptor.intercept(secondChain).close();
+            assertThrows(ApproovNetworkException.class,
+                    () -> interceptor.intercept(secondChain));
 
             // The SDK should only have been called once (for the first URL)
             approov.verify(() -> Approov.fetchApproovTokenAndWait("https://a.example.com/"));

--- a/approov-service/src/test/java/io/approov/service/retrofit/ApproovServiceContractTest.java
+++ b/approov-service/src/test/java/io/approov/service/retrofit/ApproovServiceContractTest.java
@@ -69,6 +69,7 @@ public class ApproovServiceContractTest {
     @Test
     public void fetchTokenReturnsTheSdkTokenOnSuccess() throws Exception {
         try (MockedStatic<Approov> approov = mockStatic(Approov.class)) {
+            ApproovTestSupport.initializeApproovService(approov);
             Approov.TokenFetchResult successResult = ApproovTestSupport.tokenResult(
                     Approov.TokenFetchStatus.SUCCESS,
                     "jwt-token",
@@ -85,6 +86,7 @@ public class ApproovServiceContractTest {
     @Test
     public void fetchTokenThrowsNetworkExceptionForNoNetwork() {
         try (MockedStatic<Approov> approov = mockStatic(Approov.class)) {
+            ApproovTestSupport.initializeApproovService(approov);
             Approov.TokenFetchResult noNetworkResult =
                     ApproovTestSupport.tokenResult(Approov.TokenFetchStatus.NO_NETWORK);
             approov.when(() -> Approov.fetchApproovTokenAndWait("https://example.com/reply"))
@@ -101,6 +103,7 @@ public class ApproovServiceContractTest {
     @Test
     public void fetchSecureStringAllowsUnknownKeysAndReturnsNull() throws Exception {
         try (MockedStatic<Approov> approov = mockStatic(Approov.class)) {
+            ApproovTestSupport.initializeApproovService(approov);
             Approov.TokenFetchResult unknownKeyResult = ApproovTestSupport.tokenResult(
                     Approov.TokenFetchStatus.UNKNOWN_KEY,
                     "",
@@ -117,6 +120,7 @@ public class ApproovServiceContractTest {
     @Test
     public void accountMessageSignatureReturnsTheSdkValue() throws Exception {
         try (MockedStatic<Approov> approov = mockStatic(Approov.class)) {
+            ApproovTestSupport.initializeApproovService(approov);
             approov.when(() -> Approov.getAccountMessageSignature("message"))
                     .thenReturn("base64-account-signature");
 
@@ -127,6 +131,7 @@ public class ApproovServiceContractTest {
     @Test
     public void installMessageSignatureWrapsPlatformSigningFailures() {
         try (MockedStatic<Approov> approov = mockStatic(Approov.class)) {
+            ApproovTestSupport.initializeApproovService(approov);
             approov.when(() -> Approov.getInstallMessageSignature("message"))
                     .thenThrow(new IllegalStateException("private key unavailable"));
 

--- a/approov-service/src/test/java/io/approov/service/retrofit/ApproovServiceContractTest.java
+++ b/approov-service/src/test/java/io/approov/service/retrofit/ApproovServiceContractTest.java
@@ -168,21 +168,13 @@ public class ApproovServiceContractTest {
     }
 
     @Test
-    public void interceptorFailureCacheIsScopedToRequestUrl() throws Exception {
+    public void interceptorFailureCacheAppliesToAllUrls() throws Exception {
         try (MockedStatic<Approov> approov = mockStatic(Approov.class)) {
             ApproovTestSupport.initializeApproovService(approov);
-            Approov.TokenFetchResult noServiceResult =
-                    ApproovTestSupport.tokenResult(Approov.TokenFetchStatus.NO_APPROOV_SERVICE);
-            Approov.TokenFetchResult successResult = ApproovTestSupport.tokenResult(
-                    Approov.TokenFetchStatus.SUCCESS,
-                    "jwt-token",
-                    "",
-                    "",
-                    false);
+            Approov.TokenFetchResult noNetworkResult =
+                    ApproovTestSupport.tokenResult(Approov.TokenFetchStatus.NO_NETWORK);
             approov.when(() -> Approov.fetchApproovTokenAndWait("https://a.example.com/"))
-                    .thenReturn(noServiceResult);
-            approov.when(() -> Approov.fetchApproovTokenAndWait("https://b.example.com/"))
-                    .thenReturn(successResult);
+                    .thenReturn(noNetworkResult);
 
             ApproovTokenInterceptor interceptor = new ApproovTokenInterceptor();
             Request firstRequest = new Request.Builder().url("https://a.example.com/").build();
@@ -190,13 +182,17 @@ public class ApproovServiceContractTest {
             Interceptor.Chain firstChain = ApproovTestSupport.interceptorChain(firstRequest);
             Interceptor.Chain secondChain = ApproovTestSupport.interceptorChain(secondRequest);
 
+            // First request populates the global failure cache
             interceptor.intercept(firstChain).close();
-            Response secondResponse = interceptor.intercept(secondChain);
 
-            assertEquals("jwt-token", secondResponse.request().header("Approov-Token"));
+            // Second request to a different URL should use the cached failure
+            // without calling the SDK again (NO_NETWORK is device-wide)
+            interceptor.intercept(secondChain).close();
+
+            // The SDK should only have been called once (for the first URL)
             approov.verify(() -> Approov.fetchApproovTokenAndWait("https://a.example.com/"));
-            approov.verify(() -> Approov.fetchApproovTokenAndWait("https://b.example.com/"));
-            secondResponse.close();
+            approov.verify(() -> Approov.fetchApproovTokenAndWait("https://b.example.com/"),
+                    org.mockito.Mockito.never());
         }
     }
 

--- a/approov-service/src/test/java/io/approov/service/retrofit/ApproovServiceContractTest.java
+++ b/approov-service/src/test/java/io/approov/service/retrofit/ApproovServiceContractTest.java
@@ -6,11 +6,19 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
 
+import android.content.Context;
 import com.criticalblue.approovsdk.Approov;
 
+import java.util.HashMap;
+
+import okhttp3.Interceptor;
 import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
 import retrofit2.Retrofit;
 
 import org.junit.After;
@@ -28,6 +36,65 @@ public class ApproovServiceContractTest {
     @After
     public void tearDown() {
         ApproovTestSupport.resetApproovServiceState();
+    }
+
+    @Test
+    public void initializeWithEmptyConfigDoesNotTouchNativeSdkAndBuildsStockClient() {
+        try (MockedStatic<Approov> approov = mockStatic(Approov.class)) {
+            Context context = mock(Context.class);
+
+            ApproovService.initialize(context, "", "");
+
+            assertTrue(ApproovService.isInitialized());
+            assertFalse(ApproovService.isApproovEnabled());
+
+            Retrofit retrofit = ApproovService.getRetrofit(new Retrofit.Builder()
+                    .baseUrl("https://example.com/"));
+            OkHttpClient client = ApproovTestSupport.retrofitClient(retrofit);
+
+            assertTrue(client.interceptors().stream().noneMatch(interceptor -> interceptor instanceof ApproovTokenInterceptor));
+            assertTrue(client.networkInterceptors().stream().noneMatch(interceptor -> interceptor instanceof ApproovPinningInterceptor));
+            approov.verifyNoInteractions();
+        }
+    }
+
+    @Test
+    public void initializeWithEmptyConfigCanLaterBuildProtectedClients() {
+        try (MockedStatic<Approov> approov = mockStatic(Approov.class)) {
+            approov.when(() -> Approov.getPins("public-key-sha256")).thenReturn(new HashMap<>());
+            Context context = mock(Context.class);
+            when(context.getApplicationContext()).thenReturn(context);
+
+            ApproovService.initialize(context, "", "");
+            Retrofit stockRetrofit = ApproovService.getRetrofit(new Retrofit.Builder()
+                    .baseUrl("https://example.com/"));
+            OkHttpClient stockClient = ApproovTestSupport.retrofitClient(stockRetrofit);
+
+            ApproovService.initialize(context, "dummy-config");
+            Retrofit protectedRetrofit = ApproovService.getRetrofit(new Retrofit.Builder()
+                    .baseUrl("https://example.com/"));
+            OkHttpClient protectedClient = ApproovTestSupport.retrofitClient(protectedRetrofit);
+
+            assertTrue(stockClient.interceptors().stream().noneMatch(interceptor -> interceptor instanceof ApproovTokenInterceptor));
+            assertTrue(stockClient.networkInterceptors().stream().noneMatch(interceptor -> interceptor instanceof ApproovPinningInterceptor));
+            assertTrue(protectedClient.interceptors().stream().anyMatch(interceptor -> interceptor instanceof ApproovTokenInterceptor));
+            assertTrue(protectedClient.networkInterceptors().stream().anyMatch(interceptor -> interceptor instanceof ApproovPinningInterceptor));
+            approov.verify(() -> Approov.initialize(context, "dummy-config", "auto", ""));
+            approov.verify(() -> Approov.setUserProperty("approov-service-retrofit"));
+        }
+    }
+
+    @Test
+    public void bypassModeNativeWrappersDoNotTouchNativeSdk() {
+        try (MockedStatic<Approov> approov = mockStatic(Approov.class)) {
+            Context context = mock(Context.class);
+            ApproovService.initialize(context, "", "");
+
+            assertEquals("", ApproovService.getLastARC());
+            assertThrows(ApproovException.class, () -> ApproovService.setInstallAttrsInToken("attrs"));
+            assertThrows(ApproovException.class, () -> ApproovService.setDevKey("dev-key"));
+            approov.verifyNoInteractions();
+        }
     }
 
     @Test
@@ -97,6 +164,39 @@ public class ApproovServiceContractTest {
                     () -> ApproovService.fetchToken("https://example.com/reply"));
 
             assertEquals(Approov.TokenFetchStatus.NO_NETWORK, error.getTokenFetchStatus());
+        }
+    }
+
+    @Test
+    public void interceptorFailureCacheIsScopedToRequestUrl() throws Exception {
+        try (MockedStatic<Approov> approov = mockStatic(Approov.class)) {
+            ApproovTestSupport.initializeApproovService(approov);
+            Approov.TokenFetchResult noServiceResult =
+                    ApproovTestSupport.tokenResult(Approov.TokenFetchStatus.NO_APPROOV_SERVICE);
+            Approov.TokenFetchResult successResult = ApproovTestSupport.tokenResult(
+                    Approov.TokenFetchStatus.SUCCESS,
+                    "jwt-token",
+                    "",
+                    "",
+                    false);
+            approov.when(() -> Approov.fetchApproovTokenAndWait("https://a.example.com/"))
+                    .thenReturn(noServiceResult);
+            approov.when(() -> Approov.fetchApproovTokenAndWait("https://b.example.com/"))
+                    .thenReturn(successResult);
+
+            ApproovTokenInterceptor interceptor = new ApproovTokenInterceptor();
+            Request firstRequest = new Request.Builder().url("https://a.example.com/").build();
+            Request secondRequest = new Request.Builder().url("https://b.example.com/").build();
+            Interceptor.Chain firstChain = ApproovTestSupport.interceptorChain(firstRequest);
+            Interceptor.Chain secondChain = ApproovTestSupport.interceptorChain(secondRequest);
+
+            interceptor.intercept(firstChain).close();
+            Response secondResponse = interceptor.intercept(secondChain);
+
+            assertEquals("jwt-token", secondResponse.request().header("Approov-Token"));
+            approov.verify(() -> Approov.fetchApproovTokenAndWait("https://a.example.com/"));
+            approov.verify(() -> Approov.fetchApproovTokenAndWait("https://b.example.com/"));
+            secondResponse.close();
         }
     }
 

--- a/approov-service/src/test/java/io/approov/service/retrofit/ApproovServiceMiniSdkTest.java
+++ b/approov-service/src/test/java/io/approov/service/retrofit/ApproovServiceMiniSdkTest.java
@@ -1,0 +1,603 @@
+package io.approov.service.retrofit;
+
+import android.content.Context;
+import androidx.test.core.app.ApplicationProvider;
+import com.criticalblue.minisdk.testing.AttesterProxyController;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.MediaType;
+import okhttp3.RequestBody;
+import org.json.JSONObject;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+import retrofit2.Retrofit;
+import retrofit2.converter.gson.GsonConverterFactory;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.util.Base64;
+import java.util.UUID;
+import com.criticalblue.approovsdk.Approov;
+
+import static org.junit.Assert.*;
+
+/**
+ * Integration tests for the ApproovService Retrofit service layer.
+ *
+ * Tests are organized to match the sections defined in TESTING_REQUIREMENTS.md
+ * from the core-service-layers-testing repository. Each test includes a comment
+ * referencing the requirement(s) it covers.
+ *
+ * @see <a href="https://github.com/approov/core-service-layers-testing/blob/main/TESTING_REQUIREMENTS.md">TESTING_REQUIREMENTS.md</a>
+ */
+@RunWith(RobolectricTestRunner.class)
+@Config(manifest = Config.NONE)
+public class ApproovServiceMiniSdkTest {
+    private final String validInitialConfig = "#cb-ivol#mAxOF0ekJUOC36J5XWmVmVipOcUoEdMjhPSp2FVtyTo=";
+    private Context context;
+
+    @Before
+    public void setUp() {
+        context = ApplicationProvider.getApplicationContext();
+        AttesterProxyController.reset();
+        ApproovService.initialize(context, validInitialConfig, "reinit-retrofit-tests");
+    }
+
+    @After
+    public void tearDown() {
+        ApproovService.setServiceMutator(ApproovServiceMutator.DEFAULT);
+        AttesterProxyController.reset();
+    }
+
+    // ==================================================================================
+    // SECTION 1: Initialization
+    // TESTING_REQUIREMENTS.md §1
+    // ==================================================================================
+
+    /**
+     * §1 Same Config Re-initialization / Different Config Re-initialization
+     *
+     * Re-initialize with the same config string should not fail.
+     * Re-initialize with a different config string should fail with an exception.
+     */
+    @Test
+    public void testInitializeIgnoresSameConfigAndRejectsDifferentConfig() {
+        // Re-init with same config should be ignored (no exception)
+        ApproovService.initialize(context, validInitialConfig);
+
+        // Re-init with different config should throw illegal state
+        String differentConfig = "#cb-other#mAxOF0ekJUOC36J5XWmVmVipOcUoEdMjhPSp2FVtyTo=";
+        try {
+            ApproovService.initialize(context, differentConfig);
+            fail("Expected IllegalStateException");
+        } catch (IllegalStateException e) {
+            assertEquals("ApproovService layer is already initialized.", e.getMessage());
+        }
+    }
+
+    /**
+     * §1 Empty Configuration
+     *
+     * Initializing with an empty config should keep the service layer initialized
+     * while making the returned Retrofit client behave like a plain client with no
+     * Approov mutations.
+     */
+    @Test
+    public void testInitializeWithEmptyConfigBuildsPlainClient() throws Exception {
+        reinitializeService(scenarioJson(uniqueCaseName("empty-config"),
+            "\"protectedDomains\": [\"" + getTargetHost() + "\"]"));
+        ApproovService.initialize(context, "", "reinit-empty-config");
+
+        assertTrue(ApproovService.isInitialized());
+        assertFalse(ApproovService.isApproovEnabled());
+
+        OkHttpClient client = getOkHttpClientFromRetrofit();
+        Request request = new Request.Builder()
+            .url(getTargetURL())
+            .build();
+
+        try (Response response = client.newCall(request).execute()) {
+            assertTrue(response.isSuccessful());
+            JSONObject reply = new JSONObject(response.body().string());
+            assertNull(getHeader(reply, "Approov-Token"));
+            assertNull(getHeader(reply, "Approov-TraceID"));
+        }
+    }
+
+    /**
+     * §1 Empty Configuration then Valid Configuration
+     *
+     * Initializing first with an empty config should allow a later valid config to
+     * enable Approov protection at runtime.
+     */
+    @Test
+    public void testInitializeWithEmptyConfigCanLaterEnableApproov() throws Exception {
+        reinitializeService(scenarioJson(uniqueCaseName("empty-then-valid"),
+            "\"protectedDomains\": [\"" + getTargetHost() + "\"]"));
+        ApproovService.initialize(context, "", "reinit-empty-config");
+
+        assertTrue(ApproovService.isInitialized());
+        assertFalse(ApproovService.isApproovEnabled());
+
+        OkHttpClient plainClient = getOkHttpClientFromRetrofit();
+        try (Response response = plainClient.newCall(new Request.Builder().url(getTargetURL()).build()).execute()) {
+            assertTrue(response.isSuccessful());
+            JSONObject reply = new JSONObject(response.body().string());
+            assertNull(getHeader(reply, "Approov-Token"));
+        }
+
+        ApproovService.initialize(context, validInitialConfig);
+
+        assertTrue(ApproovService.isInitialized());
+        assertTrue(ApproovService.isApproovEnabled());
+
+        OkHttpClient protectedClient = getOkHttpClientFromRetrofit();
+        try (Response response = protectedClient.newCall(new Request.Builder().url(getTargetURL()).build()).execute()) {
+            assertTrue(response.isSuccessful());
+            JSONObject reply = new JSONObject(response.body().string());
+            assertNotNull(getHeader(reply, "Approov-Token"));
+        }
+    }
+
+    // ==================================================================================
+    // SECTION 2: Request Processing & Token Behaviors
+    // TESTING_REQUIREMENTS.md §2
+    // ==================================================================================
+
+    /**
+     * §2 Precheck Evaluation
+     */
+    @Test
+    public void testPrecheckTreatsUnknownKeyAsSuccess() throws ApproovException {
+        ApproovService.precheck();
+    }
+
+    /**
+     * §2 Device ID
+     */
+    @Test
+    public void testGetDeviceIDReturnsMiniSDKDeviceID() throws ApproovException {
+        assertEquals("daIvmEWBA2gvZny7a/RC/w==", ApproovService.getDeviceID());
+    }
+
+    /**
+     * §2 Protected Request Processing / Token Binding Hash / Header & Query Substitution
+     */
+    @Test
+    public void testUpdateRequestAddsTokenTraceBindingHashAndSubstitutions() throws Exception {
+        String targetHost = getTargetHost();
+        reinitializeService(scenarioJson(uniqueCaseName("substitutions"),
+            "\"protectedDomains\": [\"" + targetHost + "\"]," +
+            "\"initialSecureStrings\": {" +
+            "  \"header-key\": \"header-secret\"," +
+            "  \"query-key\": \"query-secret\"," +
+            "  \"multiple-1\": \"secret-1\"," +
+            "  \"multiple-2\": \"secret-2\"" +
+            "}"
+        ));
+
+        ApproovService.setBindingHeader("Authorization");
+        ApproovService.addSubstitutionHeader("Api-Key", null);
+        ApproovService.addSubstitutionHeader("X-Multi-1", "pref-");
+        ApproovService.addSubstitutionHeader("X-Multi-2", null);
+        ApproovService.addSubstitutionQueryParam("api_key");
+        ApproovService.addSubstitutionQueryParam("p2");
+
+        OkHttpClient client = getOkHttpClientFromRetrofit();
+        Request request = new Request.Builder()
+            .url(getTargetURL() + "?api_key=query-key&p2=multiple-2")
+            .header("Authorization", "Bearer oauth-token")
+            .header("Api-Key", "header-key")
+            .header("X-Multi-1", "pref-multiple-1")
+            .header("X-Multi-2", "multiple-2")
+            .build();
+
+        try (Response response = client.newCall(request).execute()) {
+            JSONObject reply = new JSONObject(response.body().string());
+
+            String token = getHeader(reply, "Approov-Token");
+            assertNotNull(token);
+            assertNotNull(getHeader(reply, "Approov-TraceID"));
+            assertEquals("header-secret", getHeader(reply, "Api-Key"));
+            assertEquals("pref-secret-1", getHeader(reply, "X-Multi-1"));
+            assertEquals("secret-2", getHeader(reply, "X-Multi-2"));
+
+            String urlFromReply = reply.getString("url");
+            assertTrue(urlFromReply.contains("api_key=query-secret"));
+            assertTrue(urlFromReply.contains("p2=secret-2"));
+
+            JSONObject payload = decodeJWTBody(token);
+            assertEquals(sha256Base64("Bearer oauth-token"), payload.getString("pay"));
+        }
+    }
+
+    /**
+     * §2 Protected Request Processing — signed token with expected claims
+     */
+    @Test
+    public void testFetchTokenReturnsSignedTokenWithExpectedClaims() throws Exception {
+        reinitializeServiceWithTargetHost("");
+        String token = ApproovService.fetchToken(getTargetURL());
+        JSONObject payload = decodeJWTBody(token);
+
+        assertEquals("81.149.55.236", payload.getString("ip"));
+        assertEquals("daIvmEWBA2gvZny7a/RC/w==", payload.getString("did"));
+        assertEquals("j3AWy6", payload.getString("mskid"));
+        assertEquals("IXPSB7TRK26LXE3M", payload.getString("arc"));
+        assertTrue(payload.has("exp"));
+    }
+
+    /**
+     * §2 Missing Artifacts Fallback — NO_APPROOV_SERVICE proceeds without token
+     */
+    @Test
+    public void testUpdateRequestNoApproovServiceProceedsWithoutToken() throws Exception {
+        reinitializeServiceWithTargetHost("");
+        setDirective("{" +
+            "  \"operation\": \"fetchApproovToken\"," +
+            "  \"response\": {" +
+            "    \"status\": \"NO_APPROOV_SERVICE\"" +
+            "  }" +
+            "}");
+
+        OkHttpClient client = getOkHttpClientFromRetrofit();
+        Request request = new Request.Builder().url(getTargetURL()).build();
+        try (Response response = client.newCall(request).execute()) {
+            JSONObject reply = new JSONObject(response.body().string());
+            assertNull(getHeader(reply, "Approov-Token"));
+            assertNull(getHeader(reply, "Approov-TraceID"));
+        }
+    }
+
+    /**
+     * §2 Exclusion URL Matching
+     */
+    @Test
+    public void testUpdateRequestCanIgnoreExcludedURL() throws Exception {
+        reinitializeServiceWithTargetHost("");
+        ApproovService.addExclusionURLRegex("^.*excluded.*$");
+
+        OkHttpClient client = getOkHttpClientFromRetrofit();
+        Request request = new Request.Builder().url(getTargetURL() + "/excluded").build();
+        try (Response response = client.newCall(request).execute()) {
+            JSONObject reply = new JSONObject(response.body().string());
+            String token = getHeader(reply, "Approov-Token");
+            assertNull("Expected null Approov-Token for excluded URL, but got: " + token, token);
+        }
+    }
+
+    /**
+     * §2 Token Fallback Status — NO_NETWORK → ApproovNetworkException
+     */
+    @Test
+    public void testFetchTokenThrowsNetworkingErrorForNoNetwork() throws Exception {
+        reinitializeServiceWithTargetHost("");
+        setDirective("{" +
+            "  \"operation\": \"fetchApproovToken\"," +
+            "  \"response\": {" +
+            "    \"status\": \"NO_NETWORK\"" +
+            "  }" +
+            "}");
+
+        try {
+            ApproovService.fetchToken(getTargetURL());
+            fail("Expected ApproovNetworkException");
+        } catch (ApproovNetworkException e) {
+            assertTrue(e.getMessage().contains("fetchToken: NO_NETWORK"));
+        }
+    }
+
+    /**
+     * §2 Token Fallback Status — REJECTED → ApproovFetchStatusException
+     */
+    @Test
+    public void testFetchTokenThrowsFetchStatusExceptionForRejected() throws Exception {
+        reinitializeServiceWithTargetHost("");
+        setDirective("{" +
+            "  \"operation\": \"fetchApproovToken\"," +
+            "  \"response\": {" +
+            "    \"status\": \"REJECTED\"" +
+            "  }" +
+            "}");
+
+        try {
+            ApproovService.fetchToken(getTargetURL());
+            fail("Expected ApproovFetchStatusException");
+        } catch (ApproovFetchStatusException e) {
+            assertTrue(e.getMessage().contains("REJECTED"));
+        }
+    }
+
+    /**
+     * §2 Token Fallback Status — POOR_NETWORK → ApproovNetworkException
+     */
+    @Test
+    public void testFetchTokenThrowsNetworkExceptionForPoorNetwork() throws Exception {
+        reinitializeServiceWithTargetHost("");
+        setDirective("{" +
+            "  \"operation\": \"fetchApproovToken\"," +
+            "  \"response\": {" +
+            "    \"status\": \"POOR_NETWORK\"" +
+            "  }" +
+            "}");
+
+        try {
+            ApproovService.fetchToken(getTargetURL());
+            fail("Expected ApproovNetworkException");
+        } catch (ApproovNetworkException e) {
+            assertTrue(e.getMessage().contains("fetchToken: POOR_NETWORK"));
+        }
+    }
+
+    /**
+     * §2 Token Fallback Status — MITM_DETECTED → ApproovNetworkException
+     */
+    @Test
+    public void testFetchTokenThrowsNetworkExceptionForMitmDetected() throws Exception {
+        reinitializeServiceWithTargetHost("");
+        setDirective("{" +
+            "  \"operation\": \"fetchApproovToken\"," +
+            "  \"response\": {" +
+            "    \"status\": \"MITM_DETECTED\"" +
+            "  }" +
+            "}");
+
+        try {
+            ApproovService.fetchToken(getTargetURL());
+            fail("Expected ApproovNetworkException");
+        } catch (ApproovNetworkException e) {
+            assertTrue(e.getMessage().contains("fetchToken: MITM_DETECTED"));
+        }
+    }
+
+    // ==================================================================================
+    // SECTION 3: Service Mutators & Decision Overrides
+    // TESTING_REQUIREMENTS.md §3
+    // ==================================================================================
+
+    /**
+     * §3 Custom Mutators / Decision Overrides — override fail-closed for MITM_DETECTED
+     */
+    @Test
+    public void testServiceMutatorOverridesFailClosedBehavior() throws Exception {
+        reinitializeServiceWithTargetHost("");
+
+        setDirective("{" +
+            "  \"operation\": \"fetchApproovToken\"," +
+            "  \"response\": {" +
+            "    \"status\": \"MITM_DETECTED\"" +
+            "  }" +
+            "}");
+
+        ApproovService.setServiceMutator(new ApproovServiceMutator() {
+            @Override
+            public boolean handleInterceptorFetchTokenResult(Approov.TokenFetchResult approovResults, String url) throws ApproovException {
+                return false;
+            }
+        });
+
+        OkHttpClient client = getOkHttpClientFromRetrofit();
+        Request request = new Request.Builder().url(getTargetURL()).get().build();
+
+        try (Response response = client.newCall(request).execute()) {
+            assertEquals(200, response.code());
+            JSONObject reply = new JSONObject(response.body().string());
+            assertNull(getHeader(reply, "Approov-Token"));
+        }
+    }
+
+    // ==================================================================================
+    // SECTION 5: Message Signing
+    // TESTING_REQUIREMENTS.md §5
+    // ==================================================================================
+
+    /**
+     * §5 Install Signature Success
+     */
+    @Test
+    public void testUpdateRequestInstallMessageSigningAddsSignatureHeaders() throws Exception {
+        reinitializeServiceWithTargetHost("");
+
+        ApproovDefaultMessageSigning.SignatureParametersFactory factory =
+            ApproovDefaultMessageSigning.generateDefaultSignatureParametersFactory()
+            .setUseInstallMessageSigning();
+        ApproovService.setServiceMutator(new ApproovDefaultMessageSigning().setDefaultFactory(factory));
+
+        OkHttpClient client = getOkHttpClientFromRetrofit();
+        Request request = new Request.Builder().url(getTargetURL()).get().build();
+        try (Response response = client.newCall(request).execute()) {
+            JSONObject reply = new JSONObject(response.body().string());
+
+            assertNotNull(getHeader(reply, "Approov-Token"));
+            String signatureInput = getHeader(reply, "Signature-Input");
+            assertNotNull(signatureInput);
+            assertTrue(signatureInput.startsWith("install="));
+        }
+    }
+
+    /**
+     * §5 Account Message Signing
+     */
+    @Test
+    public void testUpdateRequestAccountMessageSigningAddsSignatureHeaders() throws Exception {
+        reinitializeServiceWithTargetHost("");
+
+        ApproovDefaultMessageSigning.SignatureParametersFactory factory =
+            ApproovDefaultMessageSigning.generateDefaultSignatureParametersFactory()
+            .setUseAccountMessageSigning();
+        ApproovService.setServiceMutator(new ApproovDefaultMessageSigning().setDefaultFactory(factory));
+
+        OkHttpClient client = getOkHttpClientFromRetrofit();
+        Request request = new Request.Builder().url(getTargetURL()).get().build();
+        try (Response response = client.newCall(request).execute()) {
+            JSONObject reply = new JSONObject(response.body().string());
+
+            assertNotNull(getHeader(reply, "Approov-Token"));
+            String signatureInput = getHeader(reply, "Signature-Input");
+            assertNotNull(signatureInput);
+            assertTrue(signatureInput.startsWith("account="));
+        }
+    }
+
+    // ==================================================================================
+    // SECTION 6: Secure Strings & Custom JWT
+    // TESTING_REQUIREMENTS.md §6
+    // ==================================================================================
+
+    /**
+     * §6 Valid Secure String Key
+     */
+    @Test
+    public void testFetchSecureStringReturnsConfiguredValue() throws ApproovException {
+        setDirective("{" +
+            "  \"operation\": \"fetchSecureString\"," +
+            "  \"response\": {" +
+            "    \"status\": \"SUCCESS\"," +
+            "    \"secureString\": \"mini-secret\"" +
+            "  }" +
+            "}");
+
+        String secureString = ApproovService.fetchSecureString("api-key", null);
+        assertEquals("mini-secret", secureString);
+    }
+
+    /**
+     * §6 Non-existent Secure String Key
+     */
+    @Test
+    public void testFetchSecureStringReturnsNilForUnknownKey() throws ApproovException {
+        setDirective("{" +
+            "  \"operation\": \"fetchSecureString\"," +
+            "  \"response\": {" +
+            "    \"status\": \"UNKNOWN_KEY\"" +
+            "  }" +
+            "}");
+
+        String secureString = ApproovService.fetchSecureString("missing-key", null);
+        assertNull(secureString);
+    }
+
+    /**
+     * §6 Custom JWT Fetch
+     */
+    @Test
+    public void testFetchCustomJWTReturnsSignedJWT() throws Exception {
+        String jwt = ApproovService.fetchCustomJWT("{\"role\":\"tester\"}");
+        assertNotNull(jwt);
+        JSONObject payload = decodeJWTBody(jwt);
+
+        assertEquals("tester", payload.getString("role"));
+        assertFalse(payload.has("exp"));
+        assertFalse(payload.has("did"));
+    }
+
+    // ==================================================================================
+    // Test Helpers
+    // ==================================================================================
+
+    /**
+     * Extracts the underlying OkHttpClient from a Retrofit instance built via
+     * ApproovService.getRetrofit(). This allows low-level request verification
+     * using OkHttp directly while still exercising the Retrofit service path.
+     */
+    private OkHttpClient getOkHttpClientFromRetrofit() {
+        Retrofit.Builder builder = new Retrofit.Builder()
+            .baseUrl(getTargetURL() + "/")
+            .addConverterFactory(GsonConverterFactory.create());
+        Retrofit retrofit = ApproovService.getRetrofit(builder);
+        return (OkHttpClient) retrofit.callFactory();
+    }
+
+    private String getTargetURL() {
+        String url = System.getenv("TESTING_REPLY_URL");
+        return (url != null) ? url : "https://replay.ivol.workers.dev";
+    }
+
+    private String getUnprotectedURL() {
+        String url = System.getenv("TESTING_REPLY_URL_UNPROTECTED");
+        return (url != null) ? url : "https://replay-unprotected.ivol.workers.dev";
+    }
+
+    private String getTargetHost() {
+        String url = getTargetURL();
+        return url.replace("https://", "").split("/")[0];
+    }
+
+    private void reinitializeServiceWithTargetHost(String scenarioBody) throws Exception {
+        String targetHost = getTargetHost();
+        String domainsJson = "\"protectedDomains\": [\"" + targetHost + "\"]," +
+                             "\"pins\": {\"public-key-sha256\": {\"" + targetHost + "\": []}}";
+        String fullBody = scenarioBody.isEmpty() ? domainsJson : domainsJson + ", " + scenarioBody;
+
+        reinitializeService(scenarioJson(uniqueCaseName("target-host"), fullBody));
+    }
+
+    private void reinitializeService(String scenarioJson) {
+        AttesterProxyController.reset();
+        if (scenarioJson != null) {
+            AttesterProxyController.loadScenarioJson(scenarioJson);
+        }
+        ApproovService.initialize(context, validInitialConfig, "reinit");
+    }
+
+    private void setDirective(String json) {
+        AttesterProxyController.setNextAttestationDirectiveJson(json);
+    }
+
+    private String uniqueCaseName(String prefix) {
+        return prefix + "-" + UUID.randomUUID().toString().toLowerCase();
+    }
+
+    private String scenarioJson(String caseName, String body) {
+        return "{" +
+            "  \"activeCase\": \"" + caseName + "\"," +
+            "  \"cases\": {" +
+            "    \"" + caseName + "\": {" +
+            "      " + body + "" +
+            "    }" +
+            "  }" +
+            "}";
+    }
+
+    private String getHeader(JSONObject reply, String key) throws Exception {
+        if (!reply.has("headers")) return null;
+        JSONObject headers = reply.getJSONObject("headers");
+        String lowerKey = key.toLowerCase();
+        if (headers.has(lowerKey)) {
+            Object val = headers.get(lowerKey);
+            if (val instanceof String) return (String) val;
+            if (val instanceof org.json.JSONArray) {
+                org.json.JSONArray arr = (org.json.JSONArray) val;
+                if (arr.length() > 0) return arr.getString(0);
+            }
+        }
+        if (headers.has(key)) {
+            Object val = headers.get(key);
+            if (val instanceof String) return (String) val;
+            if (val instanceof org.json.JSONArray) {
+                org.json.JSONArray arr = (org.json.JSONArray) val;
+                if (arr.length() > 0) return arr.getString(0);
+            }
+        }
+        return null;
+    }
+
+    private JSONObject decodeJWTBody(String jwt) throws Exception {
+        String[] parts = jwt.split("\\.");
+        if (parts.length != 3) return null;
+        byte[] bytes = Base64.getUrlDecoder().decode(parts[1]);
+        return new JSONObject(new String(bytes, StandardCharsets.UTF_8));
+    }
+
+    private String sha256Base64(String data) throws Exception {
+        MessageDigest digest = MessageDigest.getInstance("SHA-256");
+        byte[] hash = digest.digest(data.getBytes(StandardCharsets.UTF_8));
+        return Base64.getEncoder().encodeToString(hash);
+    }
+}

--- a/approov-service/src/test/java/io/approov/service/retrofit/ApproovTestSupport.java
+++ b/approov-service/src/test/java/io/approov/service/retrofit/ApproovTestSupport.java
@@ -48,8 +48,10 @@ final class ApproovTestSupport {
         setStaticField("exclusionURLRegexs", new HashMap<String, Pattern>());
         setStaticField("retrofitMap", new HashMap<Retrofit.Builder, Retrofit>());
         try {
+            setStaticField("cachedFailureKey", null);
             setStaticField("cachedFailureResult", null);
             setStaticField("cachedFailureTimeMs", 0L);
+            setStaticField("failureCacheTtlMs", 500L);
         } catch (Throwable e) {
             // ignore
         }

--- a/approov-service/src/test/java/io/approov/service/retrofit/ApproovTestSupport.java
+++ b/approov-service/src/test/java/io/approov/service/retrofit/ApproovTestSupport.java
@@ -48,7 +48,6 @@ final class ApproovTestSupport {
         setStaticField("exclusionURLRegexs", new HashMap<String, Pattern>());
         setStaticField("retrofitMap", new HashMap<Retrofit.Builder, Retrofit>());
         try {
-            setStaticField("cachedFailureKey", null);
             setStaticField("cachedFailureResult", null);
             setStaticField("cachedFailureTimeMs", 0L);
             setStaticField("failureCacheTtlMs", 500L);

--- a/approov-service/src/test/java/io/approov/service/retrofit/ApproovTestSupport.java
+++ b/approov-service/src/test/java/io/approov/service/retrofit/ApproovTestSupport.java
@@ -47,6 +47,12 @@ final class ApproovTestSupport {
         setStaticField("substitutionQueryParams", new HashMap<String, Pattern>());
         setStaticField("exclusionURLRegexs", new HashMap<String, Pattern>());
         setStaticField("retrofitMap", new HashMap<Retrofit.Builder, Retrofit>());
+        try {
+            setStaticField("cachedFailureResult", null);
+            setStaticField("cachedFailureTimeMs", 0L);
+        } catch (Throwable e) {
+            // ignore
+        }
     }
 
     static void initializeApproovService(MockedStatic<Approov> approov) {
@@ -54,7 +60,7 @@ final class ApproovTestSupport {
         approov.when(() -> Approov.getPins("public-key-sha256")).thenReturn(new HashMap<>());
         Context context = mock(Context.class);
         when(context.getApplicationContext()).thenReturn(context);
-        ApproovService.initialize(context, "", "reinit-tests");
+        ApproovService.initialize(context, "dummy-config", "reinit-tests");
     }
 
     static Approov.TokenFetchResult tokenResult(Approov.TokenFetchStatus status) {

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,7 +1,9 @@
 def localProperties = new Properties()
 def localPropertiesFile = new File(rootDir, 'local.properties')
 if (localPropertiesFile.exists()) {
-    localProperties.load(new FileInputStream(localPropertiesFile))
+    localPropertiesFile.withInputStream { inputStream ->
+        localProperties.load(inputStream)
+    }
 }
 
 def miniSdkRoot = localProperties.getProperty('miniSdkAndroidRoot', '../core-service-layers-testing/mini-sdk/android')

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,24 @@
-include ':approov-service'
+def localProperties = new Properties()
+def localPropertiesFile = new File(rootDir, 'local.properties')
+if (localPropertiesFile.exists()) {
+    localProperties.load(new FileInputStream(localPropertiesFile))
+}
+
+def miniSdkRoot = localProperties.getProperty('miniSdkAndroidRoot', '../core-service-layers-testing/mini-sdk/android')
+def approovSdkDir = new File(miniSdkRoot, 'approov-sdk')
+def testSupportDir = new File(miniSdkRoot, 'test-support')
+
+if (rootProject.name != 'approov-service') {
+    include ':approov-service'
+}
+
+if (approovSdkDir.exists() && testSupportDir.exists()) {
+    include ':approov-sdk'
+    project(':approov-sdk').projectDir = approovSdkDir
+    
+    include ':test-support'
+    project(':test-support').projectDir = testSupportDir
+} else {
+    println "WARNING: core-service-layers-testing not found at ${miniSdkRoot}."
+    println "Integration tests requiring the test-support or mini-sdk will not compile."
+}


### PR DESCRIPTION
This PR  focuses on standardizing the empty-config bypass behaviors, hardening the fail-fast logic across all direct SDK APIs, introducing thread-safe failure caching, and integrating the shared integration testing framework.

Initialization & Empty-Config Bypass
Bypass Semantics: Initializing the service with an empty configuration string ("") now successfully initializes the Retrofit service layer in a bypass mode. The underlying Retrofit client is configured and traffic passes through normally without Approov protection. A subsequent initialize call with a valid string seamlessly enables Approov protection at runtime.
Public State Exporters: Added public static boolean isInitialized() and exposed public static boolean isApproovEnabled() to safely distinguish between "service layer ready" and "native SDK actively protecting traffic".
Fail-Fast Native Helpers: Consistently gated all direct native wrappers (precheck(), fetchToken(), getDeviceID(), fetchSecureString(), getAccountMessageSignature(), etc.) on isApproovEnabled(). Calling these methods while bypassed now immediately throws an ApproovException rather than reaching down and crashing the uninitialized native SDK.
Initialization Resilience: Tightened the initialization guard to tolerate benign, cross-service-layer same-config initializations, while properly throwing on legitimate different-configuration failures.
prefetch() Obsoletion: Deprecated prefetch() as a no-op that emits a warning log, aligning it with current SDK architectural behavior where native prefetching is automatic.
Short-Lived Failure Caching
Thread-Safe Caching: Implemented a 500ms failure cache (getCachedFailure / cacheFailureIfNeeded). When the platform SDK returns a hard failure status (NO_NETWORK, POOR_NETWORK, MITM_DETECTED, NO_APPROOV_SERVICE), the result is cached. Subsequent requests within that tight window short-circuit the interceptor, avoiding redundant ~1s SDK blocking calls.
Testing & Infrastructure Standardization
Unified Integration Testing: Added comprehensive test coverage for core service flows using the cross-platform ApproovServiceMiniSdkTest.java from core-service-layers-testing.
Clean Checkout Resilience: Modified settings.gradle and build.gradle to conditionally exclude the ApproovServiceMiniSdkTest source set when the sibling test-support module is missing. This completely resolves compilation failures on clean checkouts, ensuring the repository builds perfectly in standalone or public CI environments.
