### PR TITLE
Feature/zero config r8

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -6,7 +6,14 @@ on:
       - '[0-9]+.[0-9]+.[0-9]+' # Matches tags in the form 3.3.0
 
 jobs:
+  # Gate the release on the full unit-test suite. Reuses build_and_test.yml so the
+  # test definition lives in exactly one place. Publishing only runs if this passes.
+  test:
+    uses: ./.github/workflows/build_and_test.yml
+    secrets: inherit
+
   maven-publish:
+    needs: test
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
@@ -24,6 +31,24 @@ jobs:
       
     - name: Checkout Repository
       uses: actions/checkout@v5
+
+    # Fail fast if the release tag and the CHANGELOG have drifted, before any
+    # build or publish work. The top "## [x.y.z]" entry must match the tag.
+    - name: Verify CHANGELOG matches tag
+      run: |
+        TAG="${{ github.ref_name }}"
+        # `|| true` keeps the friendly -z branch reachable: without it, errexit+pipefail
+        # would abort here on a missing header before the diagnostic below can run.
+        CHANGELOG_VERSION=$(grep -m1 -oE '^## \[[0-9]+\.[0-9]+\.[0-9]+\]' CHANGELOG.md | grep -oE '[0-9]+\.[0-9]+\.[0-9]+') || true
+        if [ -z "$CHANGELOG_VERSION" ]; then
+          echo "::error::Could not find a version header (## [x.y.z]) in CHANGELOG.md"
+          exit 1
+        fi
+        if [ "$CHANGELOG_VERSION" != "$TAG" ]; then
+          echo "::error::CHANGELOG.md top entry ($CHANGELOG_VERSION) does not match release tag ($TAG). Update CHANGELOG.md before tagging."
+          exit 1
+        fi
+        echo "CHANGELOG.md top entry matches tag: $TAG"
 
     - name: Set Up Java
       uses: actions/setup-java@v5
@@ -70,8 +95,11 @@ jobs:
         KEY_ID=$(gpg --list-keys --with-colons | grep pub | cut -d: -f5)
         echo -e "trust\n5\ny\nquit" | gpg --batch --yes --command-fd 0 --edit-key $KEY_ID
     
+    # Bake the release version (the git tag) into the AAR so the runtime user
+    # property reports it, e.g. "approov-service-retrofit/3.5.7". The tag is the
+    # same value used for the pom and artifact names, keeping them in lockstep.
     - name: Build AAR
-      run:  ./gradlew assembleRelease
+      run:  ./gradlew assembleRelease -PapproovServiceVersion=${{ github.ref_name }}
 
     - name: Create Package
       run: cd .maven && ./build-and-sign.sh

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -64,7 +64,6 @@ jobs:
           if [[ -z "$TESTING_REPLY_URL" || -z "$TESTING_REPLY_URL_UNPROTECTED" ]]; then
             echo "ERROR: TESTING_REPLY_URL and TESTING_REPLY_URL_UNPROTECTED must be"
             echo "       set as GitHub organisation or repository variables."
-            echo "       See CONTRIBUTING.md for setup instructions."
             exit 1
           fi
 

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -12,10 +12,9 @@ jobs:
       WORKSPACE: "${{ github.workspace }}"
       GIT_BRANCH: "${{ github.ref }}"
       CURRENT_TAG: "${{ github.ref_name }}"
-      # Worker endpoints: consumed from GitHub organisation variables first.
-      # If the org variable is not set the value is an empty string; the probe
-      # step below falls back to the same hardcoded defaults that are baked into
-      # the mini-sdk (MiniAttesterConfig / Approov.m), keeping them in sync.
+      # Worker endpoints: consumed from GitHub organisation or repository variables.
+      # Variables MUST be set — no hardcoded fallback is provided to avoid
+      # exposing worker endpoints in the public repository.
       # Worker management (create / redeploy) logic is centralized in the
       # core-service-layers-testing script, but invoked here when needed.
       TESTING_REPLY_URL: ${{ vars.TESTING_REPLY_URL }}
@@ -51,11 +50,8 @@ jobs:
       # -----------------------------------------------------------------------
       # 3. Verify worker endpoints (with auto-redeploy)
       #
-      #    URLs are resolved with the following precedence (mirrors the mini-sdk
-      #    fallback logic in MiniAttesterConfig / Approov.m):
-      #      1. GitHub org variable  (TESTING_REPLY_URL / _UNPROTECTED)
-      
-      #
+      #    URLs MUST be set as GitHub organisation or repository variables.
+      #    The step hard-fails if they are missing — no hardcoded fallback.
       #    If the workers are unavailable, this step invokes the management
       #    script in core-service-layers-testing to redeploy them.
       # -----------------------------------------------------------------------

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -54,7 +54,7 @@ jobs:
       #    URLs are resolved with the following precedence (mirrors the mini-sdk
       #    fallback logic in MiniAttesterConfig / Approov.m):
       #      1. GitHub org variable  (TESTING_REPLY_URL / _UNPROTECTED)
-      #      2. Mini-SDK hardcoded defaults (replay.ivol.workers.dev / ...)
+      
       #
       #    If the workers are unavailable, this step invokes the management
       #    script in core-service-layers-testing to redeploy them.
@@ -62,8 +62,18 @@ jobs:
       - name: Verify worker endpoints
         run: |
           # ── URL resolution ──────────────────────────────────────────────────
-          PROTECTED_URL="${TESTING_REPLY_URL:-https://replay.ivol.workers.dev}"
-          UNPROTECTED_URL="${TESTING_REPLY_URL_UNPROTECTED:-https://replay-unprotected.ivol.workers.dev}"
+          # URLs MUST be set as GitHub organisation or repository variables.
+          # No hardcoded fallback is provided to avoid exposing endpoints
+          # in the public repository.
+          if [[ -z "$TESTING_REPLY_URL" || -z "$TESTING_REPLY_URL_UNPROTECTED" ]]; then
+            echo "ERROR: TESTING_REPLY_URL and TESTING_REPLY_URL_UNPROTECTED must be"
+            echo "       set as GitHub organisation or repository variables."
+            echo "       See CONTRIBUTING.md for setup instructions."
+            exit 1
+          fi
+
+          PROTECTED_URL="$TESTING_REPLY_URL"
+          UNPROTECTED_URL="$TESTING_REPLY_URL_UNPROTECTED"
           
           echo "TESTING_REPLY_URL=$PROTECTED_URL"       >> "$GITHUB_ENV"
           echo "TESTING_REPLY_URL_UNPROTECTED=$UNPROTECTED_URL" >> "$GITHUB_ENV"

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -3,6 +3,9 @@ name: Build and Test
 on:
   push:
   pull_request:
+  # Allow other workflows (e.g. Maven Publish) to run this same test suite as a
+  # gating job, so the test definition stays single-sourced.
+  workflow_call:
 
 jobs:
   build-and-test:

--- a/.maven/build-and-sign.sh
+++ b/.maven/build-and-sign.sh
@@ -12,10 +12,12 @@ fi
 # Extract the tag name from GITHUB_REF
 CURRENT_TAG=$(echo "$GITHUB_REF" | sed 's|refs/tags/||')
 
-# Check if the extracted tag matches the expected format (e.g., x.y.z)
+# Check if the extracted tag matches the expected format (e.g., x.y.z).
+# This runs on the publish path, so a malformed tag must abort the release
+# rather than silently shipping a placeholder version to Maven Central.
 if [[ ! "$CURRENT_TAG" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-    echo "Error: Current Git tag ($CURRENT_TAG) does not match the required format (x.y.z) ,using 0.0.0"
-    CURRENT_TAG="0.0.0"
+    echo "Error: Current Git tag ($CURRENT_TAG) does not match the required format (x.y.z); aborting."
+    exit 1
 fi
 
 # The version of the package that will be build and will be visible in maven central

--- a/.maven/build-and-sign.sh
+++ b/.maven/build-and-sign.sh
@@ -13,11 +13,16 @@ fi
 CURRENT_TAG=$(echo "$GITHUB_REF" | sed 's|refs/tags/||')
 
 # Check if the extracted tag matches the expected format (e.g., x.y.z).
-# This runs on the publish path, so a malformed tag must abort the release
-# rather than silently shipping a placeholder version to Maven Central.
+# This script is shared by two workflows:
+#   - build_and_publish.yml: only triggers on x.y.z tags, so GITHUB_REF is always
+#     a valid release tag here (the fallback below is never reached on that path).
+#   - build_only.yml: runs on feature/** branch pushes with NO release tag, to build
+#     and package for inspection. The 0.0.0 fallback keeps those builds working.
+# Do not turn this into a hard failure — it would break every feature-branch build,
+# while the publish path is already guarded by the x.y.z tag trigger + CHANGELOG check.
 if [[ ! "$CURRENT_TAG" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-    echo "Error: Current Git tag ($CURRENT_TAG) does not match the required format (x.y.z); aborting."
-    exit 1
+    echo "Warning: Current Git ref ($CURRENT_TAG) is not a release tag (x.y.z); using 0.0.0 for this non-release build."
+    CURRENT_TAG="0.0.0"
 fi
 
 # The version of the package that will be build and will be visible in maven central

--- a/.maven/maven-publish.sh
+++ b/.maven/maven-publish.sh
@@ -25,7 +25,7 @@ fi
 #   USER_MANAGED - validate and hold as a pending deployment; nothing goes public
 #                  until you click Publish (or Drop) at central.sonatype.com.
 #                  Use this for a safe release rehearsal.
-PUBLISHING_TYPE="${PUBLISHING_TYPE:-AUTOMATIC}"
+PUBLISHING_TYPE="${PUBLISHING_TYPE:-USER_MANAGED}"
 
 # Fail fast on a typo rather than sending a bad value to Sonatype.
 if [ "$PUBLISHING_TYPE" != "AUTOMATIC" ] && [ "$PUBLISHING_TYPE" != "USER_MANAGED" ]; then

--- a/.maven/maven-publish.sh
+++ b/.maven/maven-publish.sh
@@ -19,6 +19,21 @@ if [ -z "$MAVEN_PASSWORD" ]; then
   exit 1
 fi
 
+# Publishing type for the Central Portal upload. Change this one line (or export
+# PUBLISHING_TYPE before running / set it in the workflow env) to switch modes:
+#   AUTOMATIC    - validate AND immediately release to Maven Central. IRREVERSIBLE.
+#   USER_MANAGED - validate and hold as a pending deployment; nothing goes public
+#                  until you click Publish (or Drop) at central.sonatype.com.
+#                  Use this for a safe release rehearsal.
+PUBLISHING_TYPE="${PUBLISHING_TYPE:-AUTOMATIC}"
+
+# Fail fast on a typo rather than sending a bad value to Sonatype.
+if [ "$PUBLISHING_TYPE" != "AUTOMATIC" ] && [ "$PUBLISHING_TYPE" != "USER_MANAGED" ]; then
+  echo "Error: PUBLISHING_TYPE must be 'AUTOMATIC' or 'USER_MANAGED' (got: '${PUBLISHING_TYPE}')."
+  exit 1
+fi
+echo "Publishing type: ${PUBLISHING_TYPE}"
+
 # The body artifact name
 BODY_ARTIFACT="service.retrofit-${CURRENT_TAG}.zip"
 
@@ -29,5 +44,5 @@ curl --request POST \
   --verbose \
   --header "Authorization: Bearer ${MAVEN_CREDENTIALS}" \
   --form "bundle=@${BODY_ARTIFACT}" \
-  "https://central.sonatype.com/api/v1/publisher/upload?publishingType=AUTOMATIC&name=service.retrofit"
+  "https://central.sonatype.com/api/v1/publisher/upload?publishingType=${PUBLISHING_TYPE}&name=service.retrofit"
 

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "java.configuration.updateBuildConfiguration": "interactive"
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ The format is based on Keep a Changelog and this project adheres to Semantic Ver
 
 ### Fixed
 - Enforced strict failure by throwing `IllegalArgumentException` in `ApproovService.initialize` if a malformed configuration string is provided.
+- Corrected the default initialization behavior to use a `null` comment instead of an empty string, preventing unexpected native configuration mismatches on subsequent initializations.
+- Added robust guards for `null` configuration and `null` comment parameters during service initialization, preventing unexpected `NullPointerException`s.
 
 ## [3.5.6] - 2026-04-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on Keep a Changelog and this project adheres to Semantic Ver
 - Shaded and relocated the BouncyCastle dependency (`io.approov.internal.retrofit.bouncycastle`) to prevent version collisions for consuming applications.
 - Removed the transitive `org.bouncycastle:bcprov-jdk15to18` dependency from `pom.xml`.
 - Simplified `initialize` — removed the service-layer re-initialization guards (same-config short-circuit, `reinit` comment check). The service layer forwards non-empty config directly to the platform SDK and resets its own state only after the SDK confirms success. The SDK returns `false` if already initialized with the same config (service layer logs and continues), or throws `IllegalStateException` for a different config (service layer re-throws, preserving existing state).
+- `initialize` now logs a warning when a re-initialization discards previously applied service-layer configuration (token headers, substitutions, exclusions, mutator, flags), and the reset contract plus full state/input behavior matrix is now documented on `initialize` and in REFERENCE.md.
 
 ### Fixed
 - `initialize` now explicitly throws `IllegalArgumentException` when `config` is `null`, with a clear message directing callers to pass `""` for bypass mode. Passing `null` previously caused a silent coercion to `""` which masked caller errors.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,11 @@ The format is based on Keep a Changelog and this project adheres to Semantic Ver
 ### Changed
 - Shaded and relocated the BouncyCastle dependency (`io.approov.internal.bouncycastle`) to prevent version collisions for consuming applications.
 - Removed the transitive `org.bouncycastle:bcprov-jdk15to18` dependency from `pom.xml`.
+- Simplified `initialize` — removed the service-layer re-initialization guards (same-config short-circuit, `reinit` comment check). The service layer now always resets its own state and forwards non-empty config directly to the platform SDK. The SDK returns `false` if already initialized with the same config (service layer logs and continues), or throws `IllegalStateException` for a different config (service layer re-throws).
 
 ### Fixed
-- Enforced strict failure by throwing `IllegalArgumentException` in `ApproovService.initialize` if a malformed configuration string is provided.
-- Corrected the default initialization behavior to use a `null` comment instead of an empty string, preventing unexpected native configuration mismatches on subsequent initializations.
-- Added robust guards for `null` configuration and `null` comment parameters during service initialization, preventing unexpected `NullPointerException`s.
+- `initialize` now explicitly throws `IllegalArgumentException` when `config` is `null`, with a clear message directing callers to pass `""` for bypass mode. Passing `null` previously caused a silent coercion to `""` which masked caller errors.
+- The 2-arg `initialize(context, config)` overload now correctly passes `null` (not `""`) as the comment to the native SDK, preventing unexpected re-initialization mismatches on subsequent calls.
 
 ## [3.5.6] - 2026-04-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ The format is based on Keep a Changelog and this project adheres to Semantic Ver
 - Consumer ProGuard rules (`consumer-rules.pro`) to automatically preserve native SDK interfaces and internal cryptography bounds.
 
 ### Changed
-- Shaded and relocated the BouncyCastle dependency (`io.approov.internal.bouncycastle`) to prevent version collisions for consuming applications.
+- Shaded and relocated the BouncyCastle dependency (`io.approov.internal.retrofit.bouncycastle`) to prevent version collisions for consuming applications.
 - Removed the transitive `org.bouncycastle:bcprov-jdk15to18` dependency from `pom.xml`.
 - Simplified `initialize` — removed the service-layer re-initialization guards (same-config short-circuit, `reinit` comment check). The service layer now always resets its own state and forwards non-empty config directly to the platform SDK. The SDK returns `false` if already initialized with the same config (service layer logs and continues), or throws `IllegalStateException` for a different config (service layer re-throws).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this package will be documented in this file.
 The format is based on Keep a Changelog and this project adheres to Semantic Versioning.
 
 
+## [3.5.7] - 2026-05-19
+
+### Added
+- Consumer ProGuard rules (`consumer-rules.pro`) to automatically preserve native SDK interfaces and internal cryptography bounds.
+
+### Changed
+- Shaded and relocated the BouncyCastle dependency (`io.approov.internal.bouncycastle`) to prevent version collisions for consuming applications.
+- Removed the transitive `org.bouncycastle:bcprov-jdk15to18` dependency from `pom.xml`.
+
+### Fixed
+- Enforced strict failure by throwing `IllegalArgumentException` in `ApproovService.initialize` if a malformed configuration string is provided.
+
 ## [3.5.6] - 2026-04-21
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,12 @@ The format is based on Keep a Changelog and this project adheres to Semantic Ver
 ## [3.5.7] - 2026-05-19
 
 ### Added
-- Consumer ProGuard rules (`consumer-rules.pro`) to automatically preserve native SDK interfaces and internal cryptography bounds.
+- Consumer ProGuard rules (`consumer-rules.pro`) to automatically preserve native SDK interfaces and internal cryptography bindings.
 
 ### Changed
 - Shaded and relocated the BouncyCastle dependency (`io.approov.internal.retrofit.bouncycastle`) to prevent version collisions for consuming applications.
 - Removed the transitive `org.bouncycastle:bcprov-jdk15to18` dependency from `pom.xml`.
-- Simplified `initialize` — removed the service-layer re-initialization guards (same-config short-circuit, `reinit` comment check). The service layer now always resets its own state and forwards non-empty config directly to the platform SDK. The SDK returns `false` if already initialized with the same config (service layer logs and continues), or throws `IllegalStateException` for a different config (service layer re-throws).
+- Simplified `initialize` — removed the service-layer re-initialization guards (same-config short-circuit, `reinit` comment check). The service layer forwards non-empty config directly to the platform SDK and resets its own state only after the SDK confirms success. The SDK returns `false` if already initialized with the same config (service layer logs and continues), or throws `IllegalStateException` for a different config (service layer re-throws, preserving existing state).
 
 ### Fixed
 - `initialize` now explicitly throws `IllegalArgumentException` when `config` is `null`, with a clear message directing callers to pass `""` for bypass mode. Passing `null` previously caused a silent coercion to `""` which masked caller errors.

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 Approov Integration Examples
+Copyright (c) 2026 Approov Limited
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -6,10 +6,16 @@ See [Java](https://github.com/approov/quickstart-android-java-retrofit) and [Kot
 
 ## Adding Approov Service Dependency
 The Approov integration is available via [`maven`](https://mvnrepository.com/repos/central). This allows inclusion into the project by simply specifying a dependency in the `gradle` files for the app.
-The `Maven` repository is already present in the gradle.build file so the only import you need to make is the actual service layer itself:
+The `Maven` repository is already present in the `build.gradle` file so the only import you need to make is the actual service layer itself:
 
-```
+```kotlin title="build.gradle.kts"
 implementation("io.approov:service.retrofit:3.5.7")
+```
+
+If using a Groovy `build.gradle`, use:
+
+```groovy
+implementation 'io.approov:service.retrofit:3.5.7'
 ```
 
 Make sure you do a Gradle sync (by selecting `Sync Now` in the banner at the top of the modified `.gradle` file) after making these changes.
@@ -67,7 +73,7 @@ object ClientInstance {
 }
 ```
 
-This obtains a retrofit instance includes an `OkHttp` interceptor that protects channel integrity (with either pinning or managed trust roots). The interceptor may also add `Approov-Token` or substitute app secret values, depending upon your integration choices. You should thus use this client for all API calls you may wish to protect.
+This obtains a Retrofit instance that includes an `OkHttp` interceptor that protects channel integrity (with either pinning or managed trust roots). The interceptor may also add `Approov-Token` or substitute app secret values, depending upon your integration choices. You should thus use this client for all API calls you may wish to protect.
 
 Approov errors will generate an `ApproovException`, which is a type of `IOException`. This may be further specialized into an `ApproovNetworkException`, indicating an issue with networking that should provide an option for a user initiated retry (which must make the new request with a call to the `getRetrofit` to get the latest client).
 
@@ -86,7 +92,7 @@ val retrofitBuilder = retrofit2.Retrofit.Builder().baseUrl("https://your.domain/
 val retrofit = ApproovService.getRetrofit(retrofitBuilder)
 ```
 
-This call to `setOkHttpClientBuilder` only needs to be made once. Subsequent calls to `ApproovService.getRetrofit()` will then always a `OkHttpClient` with the builder values included.
+This call to `setOkHttpClientBuilder` only needs to be made once. Subsequent calls to `ApproovService.getRetrofit()` will then always build and use an `OkHttpClient` with the builder values included.
 
 ## Checking it Works
 Initially you won't have set which API domains to protect, so the interceptor will not add anything. It will have called Approov though and made contact with the Approov cloud service. You will see logging from Approov saying `UNKNOWN_URL`.
@@ -96,7 +102,7 @@ Your Approov onboarding email should contain a link allowing you to access [Live
 ## Next Steps
 To actually protect your APIs and/or secrets there are some further steps. Approov provides two different options for protection:
 
-**API Protection** You should use this if you control the backend API(s) being protected and are able to modify them to ensure that a valid Approov token is being passed by the app. An [Approov Token](https://approov.io/docs/latest/approov-usage-documentation/#approov-tokens) is short lived crytographically signed JWT proving the authenticity of the call.
+**API Protection** You should use this if you control the backend API(s) being protected and are able to modify them to ensure that a valid Approov token is being passed by the app. An [Approov Token](https://approov.io/docs/latest/approov-usage-documentation/#approov-tokens) is short lived cryptographically signed JWT proving the authenticity of the call.
 
 **Secrets Protection** This allows app secrets, including API keys for 3rd party services, to be protected so that they no longer need to be included in the released app code. These secrets are only made available to valid apps at runtime.
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,104 @@ A wrapper for the [Approov SDK](https://github.com/approov/approov-android-sdk) 
 
 See [Java](https://github.com/approov/quickstart-android-java-retrofit) and [Kotlin](https://github.com/approov/quickstart-android-kotlin-retrofit) quickstarts for instructions on how to use this.
 
+## Adding Approov Service Dependency
+The Approov integration is available via [`maven`](https://mvnrepository.com/repos/central). This allows inclusion into the project by simply specifying a dependency in the `gradle` files for the app.
+The `Maven` repository is already present in the gradle.build file so the only import you need to make is the actual service layer itself:
+
+```
+implementation("io.approov:service.retrofit:3.5.7")
+```
+
+Make sure you do a Gradle sync (by selecting `Sync Now` in the banner at the top of the modified `.gradle` file) after making these changes.
+
+This package is actually an open source wrapper layer that allows you to easily use Approov with `Retrofit`. This has a further dependency to the closed source [Approov SDK](https://mvnrepository.com/artifact/io.approov/approov-android-sdk). In some cases you may need to also add this implementation to your dependencies list to avoid build errors:
+
+```
+implementation("io.approov:approov-android-sdk:3.5.3")
+```
+
+## Manifest Changes
+The following app permissions need to be available in the manifest to use Approov:
+
+```xml
+<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+<uses-permission android:name="android.permission.INTERNET" />
+```
+
+Note that the minimum SDK version you can use with the Approov package is 23 (Android 6.0). 
+
+Please [read this](https://approov.io/docs/latest/approov-usage-documentation/#targeting-android-11-and-above) section of the reference documentation if targeting Android 11 (API level 30) or above.
+
+## Initializing Approov Service
+In order to use the `ApproovService` you must initialize it when your app is created, usually in the `onCreate` method:
+
+```kotlin
+import io.approov.service.retrofit.ApproovService
+
+class YourApp: Application() {
+    override fun onCreate() {
+        super.onCreate()
+        ApproovService.initialize(applicationContext, "<enter-your-config-string-here>")
+    }
+}
+```
+
+The `<enter-your-config-string-here>` is a custom string that configures your Approov account access. This will have been provided in your Approov onboarding email.
+
+## Using Approov Service
+You can then modify your code that obtains a `RetrofitInstance` to make API calls as follows:
+
+```kotlin
+object ClientInstance {
+    private const val BASE_URL = "https://your.domain"
+    private var retrofitBuilder: Retrofit.Builder? = null
+    val retrofitInstance: Retrofit
+        get() {
+            if (retrofitBuilder == null) {
+                retrofitBuilder = Retrofit.Builder()
+                        .baseUrl(BASE_URL)
+                        .addConverterFactory(GsonConverterFactory.create())
+            }
+            return ApproovService.getRetrofit(retrofitBuilder!!)
+        }
+}
+```
+
+This obtains a retrofit instance includes an `OkHttp` interceptor that protects channel integrity (with either pinning or managed trust roots). The interceptor may also add `Approov-Token` or substitute app secret values, depending upon your integration choices. You should thus use this client for all API calls you may wish to protect.
+
+Approov errors will generate an `ApproovException`, which is a type of `IOException`. This may be further specialized into an `ApproovNetworkException`, indicating an issue with networking that should provide an option for a user initiated retry (which must make the new request with a call to the `getRetrofit` to get the latest client).
+
+## Custom OkHttp Builder
+By default, the Retrofit instance gets a default client constructed with a default `OkHttpClient`. However, your existing code may use a customized `OkHttpClient` with, for instance, different timeouts or other interceptors. For example, if you have existing code:
+
+```kotlin
+val client = OkHttpClient.Builder().connectTimeout(5, TimeUnit.SECONDS).build()
+val retrofit = retrofit2.Retrofit.Builder().baseUrl("https://your.domain/").client(client).build()
+```
+Pass the modified `OkHttp.Builder` to the `ApproovService` as follows:
+
+```kotlin
+ApproovService.setOkHttpClientBuilder(OkHttpClient.Builder().connectTimeout(5, TimeUnit.SECONDS))
+val retrofitBuilder = retrofit2.Retrofit.Builder().baseUrl("https://your.domain/")
+val retrofit = ApproovService.getRetrofit(retrofitBuilder)
+```
+
+This call to `setOkHttpClientBuilder` only needs to be made once. Subsequent calls to `ApproovService.getRetrofit()` will then always a `OkHttpClient` with the builder values included.
+
+## Checking it Works
+Initially you won't have set which API domains to protect, so the interceptor will not add anything. It will have called Approov though and made contact with the Approov cloud service. You will see logging from Approov saying `UNKNOWN_URL`.
+
+Your Approov onboarding email should contain a link allowing you to access [Live Metrics Graphs](https://approov.io/docs/latest/approov-usage-documentation/#metrics-graphs). After you've run your app with Approov integration you should be able to see the results in the live metrics within a minute or so. At this stage you could even release your app to get details of your app population and the attributes of the devices they are running upon.
+
+## Next Steps
+To actually protect your APIs and/or secrets there are some further steps. Approov provides two different options for protection:
+
+**API Protection** You should use this if you control the backend API(s) being protected and are able to modify them to ensure that a valid Approov token is being passed by the app. An [Approov Token](https://approov.io/docs/latest/approov-usage-documentation/#approov-tokens) is short lived crytographically signed JWT proving the authenticity of the call.
+
+**Secrets Protection** This allows app secrets, including API keys for 3rd party services, to be protected so that they no longer need to be included in the released app code. These secrets are only made available to valid apps at runtime.
+
+Note that it is possible to use both approaches side-by-side in the same app.
+
 # Changelog
 
 Please see the [CHANGELOG.md](CHANGELOG.md) for more information on the changes in each version.
@@ -18,9 +116,7 @@ Please see the [USAGE.md](USAGE.md) for more information on how to use this wrap
 
 ## Included 3rd party Source
 
-To support message signing, this repo has adapted code released by two 3rd
-party developers. The LICENSE files have been copied from the repos into the
-associated directories listed below:
+To support message signing, this repo has adapted code released by two 3rd party developers. The LICENSE files have been copied from the repos into the associated directories listed below:
 
 * `approov-service/src/main/java/io/approov/util/http/sfv`
     * Repo: https://github.com/reschke/structured-fields

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -20,6 +20,8 @@ If a method throws an `ApproovRejectionException` (a subclass of `ApproovFetchSt
 ## initialize
 Initializes the Approov SDK and thus enables the Approov features. The `config` will have been provided in the initial onboarding or email or can be [obtained](https://approov.io/docs/latest/approov-usage-documentation/#getting-the-initial-sdk-configuration) using the approov CLI. This will generate an error if a second attempt is made at initialization with a different `config`.
 
+This is the standard form and should be used in most cases. The `comment` parameter defaults to `null` when not supplied.
+
 **Java:**
 ```Java
 void initialize(Context context, String config)
@@ -34,7 +36,7 @@ The [application context](https://developer.android.com/reference/android/conten
 
 It is possible to pass an empty `config` string to indicate that no initialization of the underlying native Approov SDK is required. This initializes the service layer in a bypass mode, allowing you to obtain a standard, non-Approov protected Retrofit client. If you attempt to use any direct native Approov SDK functions (such as `fetchToken` or `precheck`) while bypassed, an `ApproovException` will be thrown. You may later call `initialize` again with a valid `config` string to enable Approov protection for Retrofit instances obtained after that point. Retrofit instances obtained while bypassed remain standard, non-Approov protected clients and should be discarded if protection is later enabled.
 
-An alternative initialization function allows to provide further options or trigger reinitialization in the `comment` parameter. Please refer to the [Approov SDK documentation](https://approov.io/docs/latest/approov-direct-sdk-integration/#sdk-initialization-options) for details.
+If you need to supply a `comment` to the native SDK (for example to pass `options:...` startup flags or trigger a `reinit...` flow), use the extended form instead:
 
 **Java:**
 ```java
@@ -43,10 +45,17 @@ void initialize(Context context, String config, String comment)
 
 **Kotlin:**
 ```kotlin
-fun initialize(context: Context, config: String, comment: String)
+fun initialize(context: Context, config: String, comment: String?)
 ```
 
-For example, options like `options:no-install-key` or reinitialization via `reinit` can be supplied via the `comment` parameter.
+The `comment` parameter is passed directly to the native Approov SDK. Key uses:
+* Pass a string starting with `options:` during the initial setup to forward custom startup options to the native SDK.
+* Pass a string starting with `reinit` to trigger native re-initialization on a subsequent same-config call.
+* Pass `null` (or use the 2-arg form) when no comment is needed — this is the default.
+
+Please refer to the [Approov SDK documentation](https://approov.io/docs/latest/approov-direct-sdk-integration/#sdk-initialization-options) for full details on supported comment values.
+
+
 
 ## isInitialized
 Indicates whether the Approov service layer has been initialized.

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -190,7 +190,7 @@ fun setProceedOnNetworkFail(proceed: Boolean)
 Note that this should be used with *CAUTION* because it may allow a connection to be established before any dynamic pins have been received via Approov, thus potentially opening the channel to a MitM.
 
 ## setUseApproovStatusIfNoToken
-If the provided `shouldUse` value is `true` then this indicates that the Approov fetch status (e.g. "NO_NETWORK", "MITM_DETECTED") should be used as the token header value if the actual token fetch fails or returns an empty token. This allows passing error condition information to the backend via the Approov-Token header, which might otherwise be empty or missing.
+If the provided `shouldUse` value is `true` then this indicates that the Approov fetch status (e.g. `"NO_NETWORK"`, `"MITM_DETECTED"`) should be used as the token header value if the actual token fetch succeeds but returns an empty token. This allows passing error condition information to the backend via the Approov token header.
 
 **Java:**
 ```Java
@@ -201,6 +201,16 @@ void setUseApproovStatusIfNoToken(boolean shouldUse)
 ```kotlin
 fun setUseApproovStatusIfNoToken(shouldUse: Boolean)
 ```
+
+**Token header behaviour when no real token is available:**
+
+| `useApproovStatusIfNoToken` | Token returned by SDK | Header emitted |
+|---|---|---|
+| `false` (default) | non-empty | `prefix + token` |
+| `false` (default) | empty | `prefix` only — header is still sent with just the configured prefix (e.g. `"Bearer "`) to signal that Approov processing occurred. The backend must be prepared to handle a prefix-only value gracefully. |
+| `true` | empty or any failure status | `prefix + statusString` (e.g. `"NO_NETWORK"`) |
+
+> **Note**: The header is always emitted when Approov processing succeeds (i.e. the mutator does not block the request). A prefix-only header value is intentional and signals to the backend that Approov ran but no signed token was available, distinguishing this from requests that bypassed Approov entirely.
 
 ## setFailureCacheTtlMs
 Sets the time-to-live (in milliseconds) for caching Approov failure statuses (such as `NO_NETWORK`, `MITM_DETECTED`, etc.) during interceptor token fetches. The default TTL is 500 milliseconds. When the service is in a sustained failure state, caching the failure avoids redundant and potentially blocking calls to the native SDK for rapidly fired concurrent requests.

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -55,6 +55,13 @@ The `comment` parameter is passed directly to the native Approov SDK. Key uses:
 
 Please refer to the [Approov SDK documentation](https://approov.io/docs/latest/approov-direct-sdk-integration/#sdk-initialization-options) for full details on supported comment values.
 
+### Re-initialization and state reset
+Configuration identity is owned by the native Approov SDK, not the service layer: any non-empty `config` is forwarded directly to the SDK, which accepts a same-config call as a no-op and rejects a different `config` (unless a `reinit...` comment is supplied).
+
+A **successful** `initialize` — including the benign same-config no-op — **resets all service-layer configuration back to defaults**: the token header and prefix, trace-ID header, binding header, substitution headers and query parameters, exclusion regexes, the service mutator, and the `proceedOnNetworkFail` / `useApproovStatusIfNoToken` flags. Follow the *initialize once, then configure* contract — apply any customization (`setApproovTokenHeader`, `addSubstitutionHeader`, `addExclusionURLRegex`, `setServiceMutator`, etc.) **after** `initialize`, otherwise a later re-initialization will silently discard it (a warning is logged when a re-init discards state).
+
+If the native SDK **rejects** the call, the service-layer state is left completely unchanged and continues operating in its current mode (protected or bypass). A subsequent `initialize` with an empty `config` on an already-protected service layer is ignored and cannot downgrade it to bypass mode.
+
 
 
 ## isInitialized

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -70,7 +70,7 @@ boolean isInitialized()
 fun isInitialized(): Boolean
 ```
 
-Returns `true` if `initialize` has been called successfully, including when bypass mode is active (empty config string). Returns `false` if `initialize` has never been called or if the last initialization attempt failed. Use `isApproovEnabled()` to distinguish between bypass and protected modes.
+Returns `true` if `initialize` has been called successfully, including when bypass mode is active (empty config string). Returns `false` if `initialize` has never been called. If a subsequent `initialize` call fails (e.g. due to a different config being rejected), the prior initialized state is preserved — the method does not flip back to `false`. Use `isApproovEnabled()` to distinguish between bypass and protected modes.
 
 ## isApproovEnabled
 Indicates whether the underlying native Approov SDK is enabled and active.
@@ -190,7 +190,7 @@ fun setProceedOnNetworkFail(proceed: Boolean)
 Note that this should be used with *CAUTION* because it may allow a connection to be established before any dynamic pins have been received via Approov, thus potentially opening the channel to a MitM.
 
 ## setUseApproovStatusIfNoToken
-If the provided `shouldUse` value is `true` then this indicates that the Approov fetch status (e.g. `"NO_NETWORK"`, `"MITM_DETECTED"`) should be used as the token header value if the actual token fetch succeeds but returns an empty token. This allows passing error condition information to the backend via the Approov token header.
+If the provided `shouldUse` value is `true` then this indicates that the Approov fetch status (e.g. `"NO_NETWORK"`, `"MITM_DETECTED"`) should be used as the token header value when a real Approov token is unavailable. This covers two cases: (1) the token fetch succeeds but returns an empty token, and (2) a failure status is returned but the active service mutator allows the request to proceed rather than aborting it. This allows passing error condition information to the backend via the Approov token header.
 
 **Java:**
 ```Java

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -70,8 +70,10 @@ boolean isInitialized()
 fun isInitialized(): Boolean
 ```
 
+Returns `true` if `initialize` has been called successfully, including when bypass mode is active (empty config string). Returns `false` if `initialize` has never been called or if the last initialization attempt failed. Use `isApproovEnabled()` to distinguish between bypass and protected modes.
+
 ## isApproovEnabled
-Indicates whether the underlying native Approov SDK is enabled and active. If the service layer was initialized with an empty configuration string, this will return `false`.
+Indicates whether the underlying native Approov SDK is enabled and active.
 
 **Java:**
 ```Java
@@ -82,6 +84,8 @@ boolean isApproovEnabled()
 ```kotlin
 fun isApproovEnabled(): Boolean
 ```
+
+Returns `true` only when the service layer was initialized with a valid, non-empty configuration string and the native Approov SDK is active. Returns `false` in all other cases: not initialized, or initialized in bypass mode (empty config). All direct Approov SDK methods (such as `fetchToken`, `precheck`, `fetchSecureString`) will throw `ApproovException` if called when this returns `false`.
 
 ## setApproovInterceptorExtensions
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -34,7 +34,7 @@ The [application context](https://developer.android.com/reference/android/conten
 
 It is possible to pass an empty `config` string to indicate that no initialization of the underlying native Approov SDK is required. This initializes the service layer in a bypass mode, allowing you to obtain a standard, non-Approov protected Retrofit client. If you attempt to use any direct native Approov SDK functions (such as `fetchToken` or `precheck`) while bypassed, an `ApproovException` will be thrown. You may later call `initialize` again with a valid `config` string to enable Approov protection for Retrofit instances obtained after that point. Retrofit instances obtained while bypassed remain standard, non-Approov protected clients and should be discarded if protection is later enabled.
 
-An alternative initialization function allows to provide further options in the `comment` parameter. Please refer to the [Approov SDK documentation](https://approov.io/docs/latest/approov-direct-sdk-integration/#sdk-initialization-options) for details.
+An alternative initialization function allows to provide further options or trigger reinitialization in the `comment` parameter. Please refer to the [Approov SDK documentation](https://approov.io/docs/latest/approov-direct-sdk-integration/#sdk-initialization-options) for details.
 
 **Java:**
 ```java
@@ -45,6 +45,8 @@ void initialize(Context context, String config, String comment)
 ```kotlin
 fun initialize(context: Context, config: String, comment: String)
 ```
+
+For example, options like `options:no-install-key` or reinitialization via `reinit` can be supplied via the `comment` parameter.
 
 ## isInitialized
 Indicates whether the Approov service layer has been initialized.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -5,11 +5,11 @@ We encourage all users of these service layers to update to the latest version f
 | Version | Supported          |
 | ------- | ------------------ |
 | 3.5.x   | :white_check_mark: |
-| < 3.3   | :x:                |
+| < 3.5.0 (3.4.0)  | :x:                |
 
 ## Reporting a Vulnerability
 
 Thank you for letting us know about possible security vulnerabilities to this project. 
 Please don’t publish details in a public issue or PR, send us a private email at support@approov.io. Please disclose which version your report refers to. 
 
-Your message will recieve a prompt reply. 
+Your message will receive a prompt reply.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,5 +1,5 @@
 
-We maintain updates and patches in the latest release. Earlier versions will still work, but will have less functionalities than later versions. 
+We maintain updates and patches in the latest release. Earlier versions will still work, but will have less functionality than later versions.
 We encourage all users of these service layers to update to the latest version for the best experience.
 
 | Version | Supported          |
@@ -9,7 +9,7 @@ We encourage all users of these service layers to update to the latest version f
 
 ## Reporting a Vulnerability
 
-Thank you for letting us know about possible security vulnerabilities to this project. 
-Please don’t publish details in a public issue or PR, send us a private email at support@approov.io. Please disclose which version your report refers to. 
+Thank you for letting us know about possible security vulnerabilities in this project. 
+Please don't publish details in a public issue or PR. Send us a private email at support@approov.io and disclose which version your report refers to. 
 
 Your message will receive a prompt reply.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,15 @@
+
+We maintain updates and patches in the latest release. Earlier versions will still work, but will have less functionalities than later versions. 
+We encourage all users of these service layers to update to the latest version for the best experience.
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 3.5.x   | :white_check_mark: |
+| < 3.3   | :x:                |
+
+## Reporting a Vulnerability
+
+Thank you for letting us know about possible security vulnerabilities to this project. 
+Please don’t publish details in a public issue or PR, send us a private email at support@approov.io. Please disclose which version your report refers to. 
+
+Your message will recieve a prompt reply. 

--- a/approov-service/build.gradle
+++ b/approov-service/build.gradle
@@ -56,7 +56,7 @@ configurations {
 tasks.register('shadowJar', com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar) {
     archiveClassifier.set('shadow')
     configurations = [project.configurations.shadowed]
-    relocate 'org.bouncycastle', 'io.approov.internal.bouncycastle'
+    relocate 'org.bouncycastle', 'io.approov.internal.retrofit.bouncycastle'
     exclude 'META-INF/**'
 }
 

--- a/approov-service/build.gradle
+++ b/approov-service/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id 'com.android.library'
+    id 'com.github.johnrengelman.shadow' version '8.1.1'
 }
 
 repositories {
@@ -14,6 +15,7 @@ android {
     defaultConfig {
         minSdkVersion 23
         targetSdkVersion 34
+        consumerProguardFiles 'consumer-rules.pro'
     }
 
     buildTypes {
@@ -47,6 +49,17 @@ android {
     }
 }
 
+configurations {
+    shadowed
+}
+
+tasks.register('shadowJar', com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar) {
+    archiveClassifier.set('shadow')
+    configurations = [project.configurations.shadowed]
+    relocate 'org.bouncycastle', 'io.approov.internal.bouncycastle'
+    exclude 'META-INF/**'
+}
+
 if (findProject(':approov-sdk') != null) {
     configurations {
         testImplementation {
@@ -58,7 +71,9 @@ if (findProject(':approov-sdk') != null) {
 dependencies {
     implementation 'com.squareup.okhttp3:okhttp:4.12.0'
     implementation 'io.approov:approov-android-sdk:3.5.3'
-    implementation 'org.bouncycastle:bcprov-jdk15to18:1.84'
+    shadowed 'org.bouncycastle:bcprov-jdk15to18:1.84'
+    compileOnly files(tasks.named('shadowJar'))
+    implementation files(tasks.named('shadowJar'))
     implementation 'com.squareup.retrofit2:retrofit:2.11.0'
     implementation 'com.squareup.retrofit2:converter-gson:2.11.0'
     implementation 'androidx.annotation:annotation-jvm:1.9.1'
@@ -73,4 +88,8 @@ dependencies {
     testImplementation 'org.robolectric:robolectric:4.11.1'
     testImplementation 'org.json:json:20231013'
     testImplementation 'androidx.test:core:1.6.1'
+}
+
+tasks.withType(JavaCompile) {
+    dependsOn tasks.named('shadowJar')
 }

--- a/approov-service/build.gradle
+++ b/approov-service/build.gradle
@@ -12,10 +12,22 @@ android {
     namespace = "io.approov.service.retrofit"
     compileSdk 34
 
+    buildFeatures {
+        // AGP 8 disables BuildConfig generation by default; we need it to expose
+        // the service-layer version to runtime code (see APPROOV_SERVICE_VERSION below).
+        buildConfig true
+    }
+
     defaultConfig {
         minSdkVersion 23
         targetSdkVersion 34
         consumerProguardFiles 'consumer-rules.pro'
+
+        // The published service-layer version, fed by CI from the release git tag
+        // (-PapproovServiceVersion=X.Y.Z). Local/test builds get "dev". This is the
+        // single source of truth for the version baked into the compiled AAR.
+        def serviceVersion = (project.findProperty('approovServiceVersion') ?: 'dev')
+        buildConfigField "String", "APPROOV_SERVICE_VERSION", "\"${serviceVersion}\""
     }
 
     buildTypes {

--- a/approov-service/consumer-rules.pro
+++ b/approov-service/consumer-rules.pro
@@ -1,0 +1,19 @@
+# Approov SDK Consumer Rules
+
+# Retain public interfaces for the app and service layer
+-keep class com.criticalblue.approovsdk.Approov {
+    public *;
+}
+-keep class com.criticalblue.approovsdk.Approov$* {
+    public *;
+}
+
+# Retain all native methods to ensure JNI binds correctly
+-keepclasseswithmembernames class com.criticalblue.approovsdk.** {
+    native <methods>;
+}
+
+# Keep classes containing native methods from being renamed, as JNI often relies on class names
+-keepnames class com.criticalblue.approovsdk.** {
+    native <methods>;
+}

--- a/approov-service/consumer-rules.pro
+++ b/approov-service/consumer-rules.pro
@@ -1,6 +1,6 @@
 # Approov SDK Consumer Rules
 
-# Retain public interfaces for the app and service layer
+# Retain public interfaces for the native Approov SDK
 -keep class com.criticalblue.approovsdk.Approov {
     public *;
 }

--- a/approov-service/pom.xml
+++ b/approov-service/pom.xml
@@ -37,12 +37,7 @@
         <version>4.12.0</version>
         <scope>runtime</scope>
     </dependency>
-    <dependency>
-      <groupId>org.bouncycastle</groupId>
-      <artifactId>bcprov-jdk15to18</artifactId>
-      <version>1.84</version>
-      <scope>runtime</scope>
-    </dependency>
+
     <dependency>
         <groupId>io.approov</groupId>
         <artifactId>approov-android-sdk</artifactId>

--- a/approov-service/src/main/java/io/approov/service/retrofit/ApproovDefaultMessageSigning.java
+++ b/approov-service/src/main/java/io/approov/service/retrofit/ApproovDefaultMessageSigning.java
@@ -20,9 +20,9 @@ package io.approov.service.retrofit;
 import android.util.Base64;
 import android.util.Log;
 
-import io.approov.internal.bouncycastle.asn1.ASN1InputStream;
-import io.approov.internal.bouncycastle.asn1.ASN1Integer;
-import io.approov.internal.bouncycastle.asn1.ASN1Sequence;
+import io.approov.internal.retrofit.bouncycastle.asn1.ASN1InputStream;
+import io.approov.internal.retrofit.bouncycastle.asn1.ASN1Integer;
+import io.approov.internal.retrofit.bouncycastle.asn1.ASN1Sequence;
 
 import java.io.IOException;
 import java.math.BigInteger;

--- a/approov-service/src/main/java/io/approov/service/retrofit/ApproovDefaultMessageSigning.java
+++ b/approov-service/src/main/java/io/approov/service/retrofit/ApproovDefaultMessageSigning.java
@@ -20,9 +20,9 @@ package io.approov.service.retrofit;
 import android.util.Base64;
 import android.util.Log;
 
-import org.bouncycastle.asn1.ASN1InputStream;
-import org.bouncycastle.asn1.ASN1Integer;
-import org.bouncycastle.asn1.ASN1Sequence;
+import io.approov.internal.bouncycastle.asn1.ASN1InputStream;
+import io.approov.internal.bouncycastle.asn1.ASN1Integer;
+import io.approov.internal.bouncycastle.asn1.ASN1Sequence;
 
 import java.io.IOException;
 import java.math.BigInteger;

--- a/approov-service/src/main/java/io/approov/service/retrofit/ApproovService.java
+++ b/approov-service/src/main/java/io/approov/service/retrofit/ApproovService.java
@@ -166,7 +166,7 @@ public class ApproovService {
 
         // If we are already initialized with a valid config, ignore any subsequent
         // empty config initialization
-        if (isInitialized && configString != null && !configString.isEmpty() && config.isEmpty()) {
+        if (isApproovEnabled() && config.isEmpty()) {
             Log.d(TAG, "ApproovService already initialized with a valid config; ignoring empty configuration");
             return;
         }

--- a/approov-service/src/main/java/io/approov/service/retrofit/ApproovService.java
+++ b/approov-service/src/main/java/io/approov/service/retrofit/ApproovService.java
@@ -146,9 +146,12 @@ public class ApproovService {
      * @param comment the comment string, or empty for no comment
      */
     public static synchronized void initialize(Context context, String config, String comment) {
+        if (config == null) {
+            config = "";
+        }
         // check if the Approov SDK is already initialized
         boolean allowEnableAfterEmptyInitialization = isInitialized && (configString != null) && configString.isEmpty() && !config.isEmpty();
-        if (isInitialized && !comment.startsWith("reinit") && !allowEnableAfterEmptyInitialization) {
+        if (isInitialized && (comment == null || !comment.startsWith("reinit")) && !allowEnableAfterEmptyInitialization) {
             if (!config.equals(configString)) {
                 throw new IllegalStateException("ApproovService layer is already initialized.");
             }
@@ -203,8 +206,8 @@ public class ApproovService {
      * @param config the configuration string, or empty for no SDK initialization
      */
     public static void initialize(Context context, String config) {
-        // default uses the empty comment string
-        initialize(context, config, "");
+        // default uses null comment
+        initialize(context, config, null);
     }
 
     /**

--- a/approov-service/src/main/java/io/approov/service/retrofit/ApproovService.java
+++ b/approov-service/src/main/java/io/approov/service/retrofit/ApproovService.java
@@ -258,7 +258,7 @@ public class ApproovService {
         isInitialized = true;
         configString = config;
         if (!config.isEmpty())
-            Approov.setUserProperty("approov-service-retrofit");
+            Approov.setUserProperty("approov-service-retrofit/" + BuildConfig.APPROOV_SERVICE_VERSION);
     }
 
     /**

--- a/approov-service/src/main/java/io/approov/service/retrofit/ApproovService.java
+++ b/approov-service/src/main/java/io/approov/service/retrofit/ApproovService.java
@@ -49,9 +49,12 @@ import okhttp3.Response;
 import retrofit2.Retrofit;
 
 /**
- * ApproovService provides a mediation layer to the Approov SDK, enabling secure token-based
- * authentication and dynamic pinning for network requests. It offers methods to initialize
- * the SDK, configure token headers, handle secure strings, and manage OkHttp clients.
+ * ApproovService provides a mediation layer to the Approov SDK, enabling secure
+ * token-based
+ * authentication and dynamic pinning for network requests. It offers methods to
+ * initialize
+ * the SDK, configure token headers, handle secure strings, and manage OkHttp
+ * clients.
  */
 public class ApproovService {
     // logging tag
@@ -63,7 +66,8 @@ public class ApproovService {
     // default prefix to be added before the Approov token by default
     private static final String APPROOV_TOKEN_PREFIX = "";
 
-    // default header that will carry any optional Approov TraceID debug value from the SDK
+    // default header that will carry any optional Approov TraceID debug value from
+    // the SDK
     private static final String APPROOV_TRACE_ID_HEADER = "Approov-TraceID";
 
     // true if the Approov SDK initialized okay
@@ -76,7 +80,8 @@ public class ApproovService {
     // Approov token
     private static boolean proceedOnNetworkFail = false;
 
-    // true if the Approov fetch status should be used as the token header value if the
+    // true if the Approov fetch status should be used as the token header value if
+    // the
     // actual token fetch fails or returns an empty token
     private static boolean useApproovStatusIfNoToken = false;
 
@@ -98,31 +103,41 @@ public class ApproovService {
     // any header to be used for binding in Approov tokens or null if not set
     private static String bindingHeader = null;
 
-    // The mutator instance used to control ApproovService behavior at key points in the flow.
-    // Unless set using the ApproovService.setServiceMutator() method, the default behaviour 
+    // The mutator instance used to control ApproovService behavior at key points in
+    // the flow.
+    // Unless set using the ApproovService.setServiceMutator() method, the default
+    // behaviour
     // defined in the default implementation of ApproovServiceMutator will be used.
     private static ApproovServiceMutator serviceMutator = ApproovServiceMutator.DEFAULT;
 
-    // map of headers that should have their values substituted for secure strings, mapped to their
+    // map of headers that should have their values substituted for secure strings,
+    // mapped to their
     // required prefixes
     private static Map<String, String> substitutionHeaders = null;
 
-    // set of query parameters that may be substituted, specified by the key name and mapped to the compiled Pattern
+    // set of query parameters that may be substituted, specified by the key name
+    // and mapped to the compiled Pattern
     private static Map<String, Pattern> substitutionQueryParams = null;
 
-    // set of URL regexs that should be excluded from any Approov protection, mapped to the compiled Pattern
+    // set of URL regexs that should be excluded from any Approov protection, mapped
+    // to the compiled Pattern
     private static Map<String, Pattern> exclusionURLRegexs = null;
 
-    // Cached failure result from the last Approov token fetch that returned a failure status.
-    // Protected by failureCacheLock for thread-safe access. This avoids redundant ~1s SDK calls
-    // when the platform is in a sustained failure state (e.g. no network, MITM detected).
+    // Cached failure result from the last Approov token fetch that returned a
+    // failure status.
+    // Protected by failureCacheLock for thread-safe access. This avoids redundant
+    // ~1s SDK calls
+    // when the platform is in a sustained failure state (e.g. no network, MITM
+    // detected).
     private static final Object failureCacheLock = new Object();
     private static Approov.TokenFetchResult cachedFailureResult = null;
     private static long cachedFailureTimeMs = 0;
     private static long failureCacheTtlMs = 500; // 0.5 seconds default
 
-    // Gate lock for the SDK fetch call. When the service-layer failure cache is empty,
-    // only ONE thread enters the SDK; all others wait on this lock and then re-check
+    // Gate lock for the SDK fetch call. When the service-layer failure cache is
+    // empty,
+    // only ONE thread enters the SDK; all others wait on this lock and then
+    // re-check
     // the failure cache. This collapses concurrent failure storms that the SDK does
     // not cache, while successful fetches use the SDK's own cache/fast path.
     // This is separate from failureCacheLock to avoid holding the cache lock during
@@ -142,45 +157,40 @@ public class ApproovService {
      * Initializes the ApproovService with an account configuration and comment.
      *
      * @param context the Application context
-     * @param config the configuration string, or empty for no SDK initialization
+     * @param config  the configuration string, or empty for no SDK initialization
      * @param comment the comment string, or empty for no comment
      */
     public static synchronized void initialize(Context context, String config, String comment) {
-        if (config == null) {
-            config = "";
+        // Reset service layer state
+        isInitialized = false;
+        proceedOnNetworkFail = false;
+        useApproovStatusIfNoToken = false;
+        okHttpBuilder = new OkHttpClient.Builder();
+        retrofitMap = new HashMap<>();
+        approovTokenHeader = APPROOV_TOKEN_HEADER;
+        approovTokenPrefix = APPROOV_TOKEN_PREFIX;
+        approovTraceIDHeader = APPROOV_TRACE_ID_HEADER;
+        bindingHeader = null;
+        serviceMutator = ApproovServiceMutator.DEFAULT;
+        substitutionHeaders = new HashMap<>();
+        substitutionQueryParams = new HashMap<>();
+        exclusionURLRegexs = new HashMap<>();
+        synchronized (failureCacheLock) {
+            cachedFailureResult = null;
+            cachedFailureTimeMs = 0;
         }
-        // check if the Approov SDK is already initialized
-        boolean allowEnableAfterEmptyInitialization = isInitialized && (configString != null) && configString.isEmpty() && !config.isEmpty();
-        if (isInitialized && (comment == null || !comment.startsWith("reinit")) && !allowEnableAfterEmptyInitialization) {
-            if (!config.equals(configString)) {
-                throw new IllegalStateException("ApproovService layer is already initialized.");
-            }
-            Log.d(TAG, "Ignoring multiple ApproovService layer initializations with the same config");
-        }
-        else {
-            // setup ready for building Retrofit instances
-            isInitialized = false;
-            proceedOnNetworkFail = false;
-            useApproovStatusIfNoToken = false;
-            okHttpBuilder = new OkHttpClient.Builder();
-            retrofitMap = new HashMap<>();
-            approovTokenHeader = APPROOV_TOKEN_HEADER;
-            approovTokenPrefix = APPROOV_TOKEN_PREFIX;
-            approovTraceIDHeader = APPROOV_TRACE_ID_HEADER;
-            bindingHeader = null;
-            serviceMutator = ApproovServiceMutator.DEFAULT;
-            substitutionHeaders = new HashMap<>();
-            substitutionQueryParams = new HashMap<>();
-            exclusionURLRegexs = new HashMap<>();
-            synchronized (failureCacheLock) {
-                cachedFailureResult = null;
-                cachedFailureTimeMs = 0;
-            }
 
-            // initialize the Approov SDK
+        // Initialize the platform SDK if not in bypass mode (empty config).
+        // The SDK returns true if initialization succeeded, false if already
+        // initialized
+        // with the same config even by another service layer instance. Any other
+        // failure (e.g. different config) throws.
+        if (!config.isEmpty()) {
             try {
-                if (!config.isEmpty())
-                    Approov.initialize(context.getApplicationContext(), config, "auto", comment);
+                boolean sdkInitialized = Approov.initialize(context.getApplicationContext(), config, "auto", comment);
+                if (!sdkInitialized) {
+                    Log.d(TAG, "Approov SDK already initialized");
+                }
             } catch (IllegalArgumentException e) {
                 Log.e(TAG, "Approov initialization failed: " + e.getMessage());
                 throw e;
@@ -188,22 +198,22 @@ public class ApproovService {
                 Log.e(TAG, "Approov initialization failed: " + e.getMessage());
                 throw e;
             }
-            if (!config.isEmpty())
-                pinningInterceptor = new ApproovPinningInterceptor();
-            else
-                pinningInterceptor = null;
-            isInitialized = true;
-            configString = config;
-            if (!config.isEmpty())
-                Approov.setUserProperty("approov-service-retrofit");
         }
+        if (!config.isEmpty())
+            pinningInterceptor = new ApproovPinningInterceptor();
+        else
+            pinningInterceptor = null;
+        isInitialized = true;
+        configString = config;
+        if (!config.isEmpty())
+            Approov.setUserProperty("approov-service-retrofit");
     }
 
     /**
      * Initializes the ApproovService with an account configuration.
      *
      * @param context the Application context
-     * @param config the configuration string, or empty for no SDK initialization
+     * @param config  the configuration string, or empty for no SDK initialization
      */
     public static void initialize(Context context, String config) {
         // default uses null comment
@@ -261,7 +271,8 @@ public class ApproovService {
     }
 
     /**
-     * Caches a failure result. Only failure statuses are cached by this service layer;
+     * Caches a failure result. Only failure statuses are cached by this service
+     * layer;
      * success caching is handled by the SDK.
      */
     static void cacheFailureIfNeeded(Approov.TokenFetchResult result) {
@@ -283,16 +294,20 @@ public class ApproovService {
     }
 
     /**
-     * Fetches an Approov token using a double-checked locking pattern on the failure cache.
+     * Fetches an Approov token using a double-checked locking pattern on the
+     * failure cache.
      * <p>
      * Fast path: if a valid cached failure exists, return it immediately (no lock).
-     * Slow path: acquire the fetch gate so only ONE thread calls the SDK. Other threads
-     * wait, then re-check the cache. This collapses N concurrent SDK calls into 1 when
+     * Slow path: acquire the fetch gate so only ONE thread calls the SDK. Other
+     * threads
+     * wait, then re-check the cache. This collapses N concurrent SDK calls into 1
+     * when
      * the platform is in a failure state (MITM, no network, etc.).
      * <p>
      * On the happy path (SDK returns a valid token), this service layer does not
      * cache the result. Subsequent threads still pass through the gate, but the SDK
-     * is expected to serve successful follow-up fetches from its own cache/fast path.
+     * is expected to serve successful follow-up fetches from its own cache/fast
+     * path.
      *
      * @param url the URL to fetch the token for
      * @return the token fetch result (from cache or fresh SDK call)
@@ -324,12 +339,18 @@ public class ApproovService {
     }
 
     /**
-     * Sets a flag indicating if the network interceptor should proceed anyway if it is
-     * not possible to obtain an Approov token due to a networking failure. If this is set
-     * then your backend API can receive calls without the expected Approov token header
-     * being added, or without header/query parameter substitutions being made. Note that
-     * this should be used with caution because it may allow a connection to be established
-     * before any dynamic pins have been received via Approov, thus potentially opening the
+     * Sets a flag indicating if the network interceptor should proceed anyway if it
+     * is
+     * not possible to obtain an Approov token due to a networking failure. If this
+     * is set
+     * then your backend API can receive calls without the expected Approov token
+     * header
+     * being added, or without header/query parameter substitutions being made. Note
+     * that
+     * this should be used with caution because it may allow a connection to be
+     * established
+     * before any dynamic pins have been received via Approov, thus potentially
+     * opening the
      * channel to a MitM.
      *
      * @param proceed is true if Approov networking fails should allow continuation
@@ -342,10 +363,12 @@ public class ApproovService {
     }
 
     /**
-     * Gets a flag indicating if the network interceptor should proceed anyway if it is
+     * Gets a flag indicating if the network interceptor should proceed anyway if it
+     * is
      * not possible to obtain an Approov token due to a networking failure.
      *
-     * @return true if Approov networking fails should allow continuation, false otherwise
+     * @return true if Approov networking fails should allow continuation, false
+     *         otherwise
      * @deprecated Use setServiceMutator to control this behavior
      */
     @Deprecated
@@ -370,7 +393,8 @@ public class ApproovService {
     }
 
     /**
-     * Gets a flag indicating if the Approov fetch status should be used as the token header value
+     * Gets a flag indicating if the Approov fetch status should be used as the
+     * token header value
      * if the actual token fetch fails or returns an empty token.
      *
      * @return true if the status should be used as the token value, false otherwise
@@ -380,9 +404,12 @@ public class ApproovService {
     }
 
     /**
-     * Sets a development key indicating that the app is a development version and it should
-     * pass attestation even if the app is not registered or it is running on an emulator. The
-     * development key value can be rotated at any point in the account if a version of the app
+     * Sets a development key indicating that the app is a development version and
+     * it should
+     * pass attestation even if the app is not registered or it is running on an
+     * emulator. The
+     * development key value can be rotated at any point in the account if a version
+     * of the app
      * containing the development key is accidentally released. This is primarily
      * used for situations where the app package must be modified or resigned in
      * some way as part of the testing process.
@@ -398,11 +425,9 @@ public class ApproovService {
         try {
             Approov.setDevKey(devKey);
             Log.d(TAG, "setDevKey");
-        }
-        catch (IllegalStateException e) {
+        } catch (IllegalStateException e) {
             throw new ApproovException("IllegalState: " + e.getMessage());
-        }
-        catch (IllegalArgumentException e) {
+        } catch (IllegalArgumentException e) {
             throw new ApproovException("IllegalArgument: " + e.getMessage());
         }
     }
@@ -438,7 +463,8 @@ public class ApproovService {
      * Gets the name of the header that is used to hold the optional Approov
      * TraceID.
      *
-     * @return String the name of the header used for the Approov TraceID, or null if disabled
+     * @return String the name of the header used for the Approov TraceID, or null
+     *         if disabled
      */
     public static synchronized String getApproovTraceIDHeader() {
         return approovTraceIDHeader;
@@ -463,10 +489,14 @@ public class ApproovService {
     }
 
     /**
-     * Sets a binding header that must be present on all requests using the Approov service. A
-     * header should be chosen whose value is unchanging for most requests (such as an
-     * Authorization header). A hash of the header value is included in the issued Approov tokens
-     * to bind them to the value. This may then be verified by the backend API integration. This
+     * Sets a binding header that must be present on all requests using the Approov
+     * service. A
+     * header should be chosen whose value is unchanging for most requests (such as
+     * an
+     * Authorization header). A hash of the header value is included in the issued
+     * Approov tokens
+     * to bind them to the value. This may then be verified by the backend API
+     * integration. This
      * method should typically only be called once.
      *
      * @param header is the header to use for Approov token binding
@@ -528,7 +558,8 @@ public class ApproovService {
      * Gets the interceptor extensions callback handlers if the active mutator is an
      * ApproovInterceptorExtensions instance, or null otherwise.
      *
-     * @return the interceptor extensions callback handlers, or null if none set or the active
+     * @return the interceptor extensions callback handlers, or null if none set or
+     *         the active
      *         mutator is not an ApproovInterceptorExtensions
      * @deprecated Use getServiceMutator instead
      */
@@ -542,16 +573,23 @@ public class ApproovService {
     }
 
     /**
-     * Adds the name of a header which should be subject to secure strings substitution. This
-     * means that if the header is present then the value will be used as a key to look up a
-     * secure string value which will be substituted into the header value instead. This allows
-     * easy migration to the use of secure strings. Note that this function should be called on initialization
-     * rather than for every request as it will require a new OkHttpClient to be built. A required
-     * prefix may be specified to deal with cases such as the use of "Bearer " prefixed before values
+     * Adds the name of a header which should be subject to secure strings
+     * substitution. This
+     * means that if the header is present then the value will be used as a key to
+     * look up a
+     * secure string value which will be substituted into the header value instead.
+     * This allows
+     * easy migration to the use of secure strings. Note that this function should
+     * be called on initialization
+     * rather than for every request as it will require a new OkHttpClient to be
+     * built. A required
+     * prefix may be specified to deal with cases such as the use of "Bearer "
+     * prefixed before values
      * in an authorization header.
      *
-     * @param header is the header to be marked for substitution
-     * @param requiredPrefix is any required prefix to the value being substituted or null if not required
+     * @param header         is the header to be marked for substitution
+     * @param requiredPrefix is any required prefix to the value being substituted
+     *                       or null if not required
      */
     public static synchronized void addSubstitutionHeader(String header, String requiredPrefix) {
         if (isInitialized) {
@@ -578,18 +616,24 @@ public class ApproovService {
     /**
      * Gets the map of headers that are subject to substitution.
      *
-     * @return a map of headers that are subject to substitution, mapped to the required prefix
+     * @return a map of headers that are subject to substitution, mapped to the
+     *         required prefix
      */
     public static synchronized Map<String, String> getSubstitutionHeaders() {
         return new HashMap<>(substitutionHeaders);
     }
 
     /**
-     * Adds a key name for a query parameter that should be subject to secure strings substitution.
-     * This means that if the query parameter is present in a URL then the value will be used as a
-     * key to look up a secure string value which will be substituted as the query parameter value
-     * instead. This allows easy migration to the use of secure strings. Note that this function
-     * should be called on initialization rather than for every request as it will require a new
+     * Adds a key name for a query parameter that should be subject to secure
+     * strings substitution.
+     * This means that if the query parameter is present in a URL then the value
+     * will be used as a
+     * key to look up a secure string value which will be substituted as the query
+     * parameter value
+     * instead. This allows easy migration to the use of secure strings. Note that
+     * this function
+     * should be called on initialization rather than for every request as it will
+     * require a new
      * OkHttpClient to be built.
      *
      * @param key is the query parameter key name to be added for substitution
@@ -600,15 +644,15 @@ public class ApproovService {
             try {
                 Pattern pattern = Pattern.compile("[\\?&]" + key + "=([^&;]+)");
                 substitutionQueryParams.put(key, pattern);
-            }
-            catch (PatternSyntaxException e) {
+            } catch (PatternSyntaxException e) {
                 Log.e(TAG, "addSubstitutionQueryParam " + key + " error: " + e.getMessage());
             }
         }
     }
 
     /**
-     * Removes a query parameter key name previously added using addSubstitutionQueryParam.
+     * Removes a query parameter key name previously added using
+     * addSubstitutionQueryParam.
      *
      * @param key is the query parameter key name to be removed for substitution
      */
@@ -622,25 +666,37 @@ public class ApproovService {
     /**
      * Gets the map of substitution query parameters.
      *
-     * @return a map of query parameters to be substituted, mapped to the compiled Pattern
+     * @return a map of query parameters to be substituted, mapped to the compiled
+     *         Pattern
      */
     public static synchronized Map<String, Pattern> getSubstitutionQueryParams() {
         return new HashMap<>(substitutionQueryParams);
     }
 
     /**
-     * Adds an exclusion URL regular expression. If a URL for a request matches this regular expression
-     * then it will not be subject to any Approov protection. Note that this facility must be used with
-     * EXTREME CAUTION due to the impact of dynamic pinning. Pinning may be applied to all domains added
-     * using Approov, and updates to the pins are received when an Approov fetch is performed. If you
-     * exclude some URLs on domains that are protected with Approov, then these will be protected with
-     * Approov pins but without a path to update the pins until a URL is used that is not excluded. Thus
-     * you are responsible for ensuring that there is always a possibility of calling a non-excluded
-     * URL, or you should make an explicit call to fetchToken if there are persistent pinning failures.
-     * Conversely, use of those option may allow a connection to be established before any dynamic pins
-     * have been received via Approov, thus potentially opening the channel to a MitM.
+     * Adds an exclusion URL regular expression. If a URL for a request matches this
+     * regular expression
+     * then it will not be subject to any Approov protection. Note that this
+     * facility must be used with
+     * EXTREME CAUTION due to the impact of dynamic pinning. Pinning may be applied
+     * to all domains added
+     * using Approov, and updates to the pins are received when an Approov fetch is
+     * performed. If you
+     * exclude some URLs on domains that are protected with Approov, then these will
+     * be protected with
+     * Approov pins but without a path to update the pins until a URL is used that
+     * is not excluded. Thus
+     * you are responsible for ensuring that there is always a possibility of
+     * calling a non-excluded
+     * URL, or you should make an explicit call to fetchToken if there are
+     * persistent pinning failures.
+     * Conversely, use of those option may allow a connection to be established
+     * before any dynamic pins
+     * have been received via Approov, thus potentially opening the channel to a
+     * MitM.
      *
-     * @param urlRegex is the regular expression that will be compared against URLs to exclude them
+     * @param urlRegex is the regular expression that will be compared against URLs
+     *                 to exclude them
      */
     public static synchronized void addExclusionURLRegex(String urlRegex) {
         if (isInitialized) {
@@ -655,9 +711,11 @@ public class ApproovService {
     }
 
     /**
-     * Removes an exclusion URL regular expression previously added using addExclusionURLRegex.
+     * Removes an exclusion URL regular expression previously added using
+     * addExclusionURLRegex.
      *
-     * @param urlRegex is the regular expression that will be compared against URLs to exclude them
+     * @param urlRegex is the regular expression that will be compared against URLs
+     *                 to exclude them
      */
     public static synchronized void removeExclusionURLRegex(String urlRegex) {
         if (isInitialized) {
@@ -669,18 +727,22 @@ public class ApproovService {
     /**
      * Gets a copy of the current exclusion URL regexs.
      *
-     * @return Map<String, Pattern> of the exclusion regexs to their respective Patterns
+     * @return Map<String, Pattern> of the exclusion regexs to their respective
+     *         Patterns
      */
     static synchronized Map<String, Pattern> getExclusionURLRegexs() {
         return new HashMap<>(exclusionURLRegexs);
     }
 
     /**
-     * Prefetches in the background to lower the effective latency of a subsequent token fetch or
-     * secure string fetch by starting the operation earlier so the subsequent fetch may be able to
+     * Prefetches in the background to lower the effective latency of a subsequent
+     * token fetch or
+     * secure string fetch by starting the operation earlier so the subsequent fetch
+     * may be able to
      * use cached data.
      * <p>
-     * Note: This method is obsolete and is now a no-op. The underlying Approov SDK manages prefetching automatically.
+     * Note: This method is obsolete and is now a no-op. The underlying Approov SDK
+     * manages prefetching automatically.
      */
     @Deprecated
     public static synchronized void prefetch() {
@@ -688,12 +750,18 @@ public class ApproovService {
     }
 
     /**
-     * Performs a precheck to determine if the app will pass attestation. This requires secure
-     * strings to be enabled for the account, although no strings need to be set up. This will
-     * likely require network access so may take some time to complete. It may throw ApproovException
-     * if the precheck fails or if there is some other problem. ApproovRejectionException is thrown
-     * if the app has failed Approov checks or ApproovNetworkException for networking issues where a
-     * user initiated retry of the operation should be allowed. An ApproovRejectionException may provide
+     * Performs a precheck to determine if the app will pass attestation. This
+     * requires secure
+     * strings to be enabled for the account, although no strings need to be set up.
+     * This will
+     * likely require network access so may take some time to complete. It may throw
+     * ApproovException
+     * if the precheck fails or if there is some other problem.
+     * ApproovRejectionException is thrown
+     * if the app has failed Approov checks or ApproovNetworkException for
+     * networking issues where a
+     * user initiated retry of the operation should be allowed. An
+     * ApproovRejectionException may provide
      * additional information about the cause of the rejection.
      *
      * @throws ApproovException if there was a problem
@@ -708,11 +776,9 @@ public class ApproovService {
         try {
             approovResults = Approov.fetchSecureStringAndWait("precheck-dummy-key", null);
             Log.d(TAG, "precheck: " + approovResults.getStatus().toString());
-        }
-        catch (IllegalStateException e) {
+        } catch (IllegalStateException e) {
             throw new ApproovException("IllegalState: " + e.getMessage());
-        }
-        catch (IllegalArgumentException e) {
+        } catch (IllegalArgumentException e) {
             throw new ApproovException("IllegalArgument: " + e.getMessage());
         }
 
@@ -721,8 +787,10 @@ public class ApproovService {
     }
 
     /**
-     * Gets the device ID used by Approov to identify the particular device that the SDK is running on. Note
-     * that different Approov apps on the same device will return a different ID. Moreover, the ID may be
+     * Gets the device ID used by Approov to identify the particular device that the
+     * SDK is running on. Note
+     * that different Approov apps on the same device will return a different ID.
+     * Moreover, the ID may be
      * changed by an uninstall and reinstall of the app.
      *
      * @return String of the device ID
@@ -737,18 +805,21 @@ public class ApproovService {
             String deviceID = Approov.getDeviceID();
             Log.d(TAG, "getDeviceID: " + deviceID);
             return deviceID;
-        }
-        catch (IllegalStateException e) {
+        } catch (IllegalStateException e) {
             throw new ApproovException("IllegalState: " + e.getMessage());
         }
     }
 
     /**
-     * Directly sets the data hash to be included in subsequently fetched Approov tokens. If the hash is
-     * different from any previously set value then this will cause the next token fetch operation to
+     * Directly sets the data hash to be included in subsequently fetched Approov
+     * tokens. If the hash is
+     * different from any previously set value then this will cause the next token
+     * fetch operation to
      * fetch a new token with the correct payload data hash. The hash appears in the
-     * 'pay' claim of the Approov token as a base64 encoded string of the SHA256 hash of the
-     * data. Note that the data is hashed locally and never sent to the Approov cloud service.
+     * 'pay' claim of the Approov token as a base64 encoded string of the SHA256
+     * hash of the
+     * data. Note that the data is hashed locally and never sent to the Approov
+     * cloud service.
      *
      * @param data is the data to be hashed and set in the token
      * @throws ApproovException if there was a problem
@@ -761,22 +832,26 @@ public class ApproovService {
         try {
             Approov.setDataHashInToken(data);
             Log.d(TAG, "setDataHashInToken");
-        }
-        catch (IllegalStateException e) {
+        } catch (IllegalStateException e) {
             throw new ApproovException("IllegalState: " + e.getMessage());
-        }
-        catch (IllegalArgumentException e) {
+        } catch (IllegalArgumentException e) {
             throw new ApproovException("IllegalArgument: " + e.getMessage());
         }
     }
 
     /**
-     * Performs an Approov token fetch for the given URL. This should be used in situations where it
-     * is not possible to use the networking interception to add the token. This will
-     * likely require network access so may take some time to complete. If the attestation fails
-     * for any reason then an ApproovException is thrown. This will be ApproovNetworkException for
-     * networking issues where a user initiated retry of the operation should be allowed. Note that
-     * the returned token should NEVER be cached by your app, you should call this function when
+     * Performs an Approov token fetch for the given URL. This should be used in
+     * situations where it
+     * is not possible to use the networking interception to add the token. This
+     * will
+     * likely require network access so may take some time to complete. If the
+     * attestation fails
+     * for any reason then an ApproovException is thrown. This will be
+     * ApproovNetworkException for
+     * networking issues where a user initiated retry of the operation should be
+     * allowed. Note that
+     * the returned token should NEVER be cached by your app, you should call this
+     * function when
      * it is needed.
      *
      * @param url is the full URL (including path) for the token fetch
@@ -793,11 +868,9 @@ public class ApproovService {
         try {
             approovResults = Approov.fetchApproovTokenAndWait(url);
             Log.d(TAG, "fetchToken: " + approovResults.getStatus().toString());
-        }
-        catch (IllegalStateException e) {
+        } catch (IllegalStateException e) {
             throw new ApproovException("IllegalState: " + e.getMessage());
-        }
-        catch (IllegalArgumentException e) {
+        } catch (IllegalArgumentException e) {
             throw new ApproovException("IllegalArgument: " + e.getMessage());
         }
 
@@ -807,12 +880,18 @@ public class ApproovService {
     }
 
     /**
-     * Gets the signature for the given message. This uses an account specific message signing key that is
-     * transmitted to the SDK after a successful fetch if the facility is enabled for the account. Note
-     * that if the attestation failed then the signing key provided is actually random so that the
-     * signature will be incorrect. An Approov token should always be included in the message
-     * being signed and sent alongside this signature to prevent replay attacks. If no signature is
-     * available, because there has been no prior fetch or the feature is not enabled, then an
+     * Gets the signature for the given message. This uses an account specific
+     * message signing key that is
+     * transmitted to the SDK after a successful fetch if the facility is enabled
+     * for the account. Note
+     * that if the attestation failed then the signing key provided is actually
+     * random so that the
+     * signature will be incorrect. An Approov token should always be included in
+     * the message
+     * being signed and sent alongside this signature to prevent replay attacks. If
+     * no signature is
+     * available, because there has been no prior fetch or the feature is not
+     * enabled, then an
      * ApproovException is thrown.
      * <p>
      * Deprecated: use getAccountMessageSignature instead
@@ -827,12 +906,18 @@ public class ApproovService {
     }
 
     /**
-     * Gets the signature for the given message. This uses an account specific message signing key that is
-     * transmitted to the SDK after a successful fetch if the facility is enabled for the account. Note
-     * that if the attestation failed then the signing key provided is actually random so that the
-     * signature will be incorrect. An Approov token should always be included in the message
-     * being signed and sent alongside this signature to prevent replay attacks. If no signature is
-     * available, because there has been no prior fetch or the feature is not enabled, then an
+     * Gets the signature for the given message. This uses an account specific
+     * message signing key that is
+     * transmitted to the SDK after a successful fetch if the facility is enabled
+     * for the account. Note
+     * that if the attestation failed then the signing key provided is actually
+     * random so that the
+     * signature will be incorrect. An Approov token should always be included in
+     * the message
+     * being signed and sent alongside this signature to prevent replay attacks. If
+     * no signature is
+     * available, because there has been no prior fetch or the feature is not
+     * enabled, then an
      * ApproovException is thrown.
      *
      * @param message is the message whose content is to be signed
@@ -850,26 +935,30 @@ public class ApproovService {
             if (signature == null)
                 throw new ApproovException("no account signature available");
             return signature;
-        }
-        catch (IllegalStateException e) {
+        } catch (IllegalStateException e) {
             throw new ApproovException("IllegalState: " + e.getMessage());
-        }
-        catch (IllegalArgumentException e) {
+        } catch (IllegalArgumentException e) {
             throw new ApproovException("IllegalArgument: " + e.getMessage());
         }
     }
 
     /**
-     * Gets the install signature for the given message. This uses an app install specific message
-     * signing key that is generated the first time an app launches. This signing mechanism uses an
-     * ECC key pair where the private key is managed by the secure element or trusted execution
-     * environment of the device. Where it can, Approov uses attested key pairs to perform the
+     * Gets the install signature for the given message. This uses an app install
+     * specific message
+     * signing key that is generated the first time an app launches. This signing
+     * mechanism uses an
+     * ECC key pair where the private key is managed by the secure element or
+     * trusted execution
+     * environment of the device. Where it can, Approov uses attested key pairs to
+     * perform the
      * message signing.
      * <p>
-     * An Approov token should always be included in the message being signed and sent alongside
+     * An Approov token should always be included in the message being signed and
+     * sent alongside
      * this signature to prevent replay attacks.
      * <p>
-     * If no signature is available, because there has been no prior fetch or the feature is not
+     * If no signature is available, because there has been no prior fetch or the
+     * feature is not
      * enabled, then an ApproovException is thrown.
      *
      * @param message is the message whose content is to be signed
@@ -887,29 +976,37 @@ public class ApproovService {
             if (signature == null)
                 throw new ApproovException("no device signature available");
             return signature;
-        }
-        catch (IllegalStateException e) {
+        } catch (IllegalStateException e) {
             throw new ApproovException("IllegalState: " + e.getMessage());
-        }
-        catch (IllegalArgumentException e) {
+        } catch (IllegalArgumentException e) {
             throw new ApproovException("IllegalArgument: " + e.getMessage());
         }
     }
 
     /**
      * Fetches a secure string with the given key. If newDef is not null then a
-     * secure string for the particular app instance may be defined. In this case the
-     * new value is returned as the secure string. Use of an empty string for newDef removes
-     * the string entry. Note that this call may require network transaction and thus may block
-     * for some time, so should not be called from the UI thread. If the attestation fails
-     * for any reason then an ApproovException is thrown. This will be ApproovRejectionException
-     * if the app has failed Approov checks or ApproovNetworkException for networking issues where
-     * a user initiated retry of the operation should be allowed. Note that the returned string
-     * should NEVER be cached by your app, you should call this function when it is needed.
+     * secure string for the particular app instance may be defined. In this case
+     * the
+     * new value is returned as the secure string. Use of an empty string for newDef
+     * removes
+     * the string entry. Note that this call may require network transaction and
+     * thus may block
+     * for some time, so should not be called from the UI thread. If the attestation
+     * fails
+     * for any reason then an ApproovException is thrown. This will be
+     * ApproovRejectionException
+     * if the app has failed Approov checks or ApproovNetworkException for
+     * networking issues where
+     * a user initiated retry of the operation should be allowed. Note that the
+     * returned string
+     * should NEVER be cached by your app, you should call this function when it is
+     * needed.
      *
-     * @param key is the secure string key to be looked up
-     * @param newDef is any new definition for the secure string, or null for lookup only
-     * @return secure string (should not be cached by your app) or null if it was not defined
+     * @param key    is the secure string key to be looked up
+     * @param newDef is any new definition for the secure string, or null for lookup
+     *               only
+     * @return secure string (should not be cached by your app) or null if it was
+     *         not defined
      * @throws ApproovException if there was a problem
      */
     public static String fetchSecureString(String key, String newDef) throws ApproovException {
@@ -922,16 +1019,15 @@ public class ApproovService {
         if (newDef != null)
             type = "definition";
 
-        // fetch any secure string keyed by the value, catching any exceptions the SDK might throw
+        // fetch any secure string keyed by the value, catching any exceptions the SDK
+        // might throw
         Approov.TokenFetchResult approovResults;
         try {
             approovResults = Approov.fetchSecureStringAndWait(key, newDef);
             Log.d(TAG, "fetchSecureString " + type + ": " + key + ", " + approovResults.getStatus().toString());
-        }
-        catch (IllegalStateException e) {
+        } catch (IllegalStateException e) {
             throw new ApproovException("IllegalState: " + e.getMessage());
-        }
-        catch (IllegalArgumentException e) {
+        } catch (IllegalArgumentException e) {
             throw new ApproovException("IllegalArgument: " + e.getMessage());
         }
 
@@ -941,11 +1037,16 @@ public class ApproovService {
     }
 
     /**
-     * Fetches a custom JWT with the given payload. Note that this call will require network
-     * transaction and thus will block for some time, so should not be called from the UI thread.
-     * If the attestation fails for any reason then an IOException is thrown. This will be
-     * ApproovRejectionException if the app has failed Approov checks or ApproovNetworkException
-     * for networking issues where a user initiated retry of the operation should be allowed.
+     * Fetches a custom JWT with the given payload. Note that this call will require
+     * network
+     * transaction and thus will block for some time, so should not be called from
+     * the UI thread.
+     * If the attestation fails for any reason then an IOException is thrown. This
+     * will be
+     * ApproovRejectionException if the app has failed Approov checks or
+     * ApproovNetworkException
+     * for networking issues where a user initiated retry of the operation should be
+     * allowed.
      *
      * @param payload is the marshaled JSON object for the claims to be included
      * @return custom JWT string
@@ -961,11 +1062,9 @@ public class ApproovService {
         try {
             approovResults = Approov.fetchCustomJWTAndWait(payload);
             Log.d(TAG, "fetchCustomJWT: " + approovResults.getStatus().toString());
-        }
-        catch (IllegalStateException e) {
+        } catch (IllegalStateException e) {
             throw new ApproovException("IllegalState: " + e.getMessage());
-        }
-        catch (IllegalArgumentException e) {
+        } catch (IllegalArgumentException e) {
             throw new ApproovException("IllegalArgument: " + e.getMessage());
         }
 
@@ -978,9 +1077,13 @@ public class ApproovService {
      * Gets the last ARC (Attestation Response Code) code.
      *
      * Always resolves with a string (ARC or empty string).
-     * NOTE: You MUST only call this method upon succesfull attestation completion. Any networking
-     * errors returned from the service layer will not return a meaningful ARC code if the method is called!!!
-     * @return String ARC from last attestation request or empty string if network unavailable
+     * NOTE: You MUST only call this method upon succesfull attestation completion.
+     * Any networking
+     * errors returned from the service layer will not return a meaningful ARC code
+     * if the method is called!!!
+     * 
+     * @return String ARC from last attestation request or empty string if network
+     *         unavailable
      */
     public static String getLastARC() {
         if (!isApproovEnabled()) {
@@ -993,7 +1096,8 @@ public class ApproovService {
             Log.e(TAG, "ApproovService: no host pinning information available");
             return "";
         }
-        // The approovPins contains a map of hostnames to pin strings. Skip '*' and use another hostname if available.
+        // The approovPins contains a map of hostnames to pin strings. Skip '*' and use
+        // another hostname if available.
         String hostname = null;
         for (String key : approovPins.keySet()) {
             if (!"*".equals(key)) {
@@ -1023,15 +1127,20 @@ public class ApproovService {
     }
 
     /**
-     * Sets an install attributes token to be sent to the server and associated with this particular
-     * app installation for future Approov token fetches. The token must be signed, within its
-     * expiry time and bound to the correct device ID for it to be accepted by the server.
+     * Sets an install attributes token to be sent to the server and associated with
+     * this particular
+     * app installation for future Approov token fetches. The token must be signed,
+     * within its
+     * expiry time and bound to the correct device ID for it to be accepted by the
+     * server.
      * Calling this method ensures that the next call to fetch an Approov
-     * token will not use a cached version, so that this information can be transmitted to the server.
+     * token will not use a cached version, so that this information can be
+     * transmitted to the server.
      *
      * @param attrs is the signed JWT holding the new install attributes
      * @return void
-     * @throws ApproovException if the attrs parameter is invalid or the SDK is not initialized
+     * @throws ApproovException if the attrs parameter is invalid or the SDK is not
+     *                          initialized
      */
     public static void setInstallAttrsInToken(String attrs) throws ApproovException {
         if (!isApproovEnabled()) {
@@ -1051,7 +1160,8 @@ public class ApproovService {
     }
 
     /**
-     * Rebuilds the pins in the pinning interceptor after a dynamic configuration change.
+     * Rebuilds the pins in the pinning interceptor after a dynamic configuration
+     * change.
      */
     static synchronized void rebuildPins() {
         if (pinningInterceptor != null)
@@ -1059,9 +1169,12 @@ public class ApproovService {
     }
 
     /**
-     * Sets the OkHttpClient.Builder to be used for constructing the OkHttpClients used in the
-     * Retrofit instances. This allows a custom configuration to be set, with additional interceptors
-     * and properties. This clears the cached Retrofit client instances so should only be called when
+     * Sets the OkHttpClient.Builder to be used for constructing the OkHttpClients
+     * used in the
+     * Retrofit instances. This allows a custom configuration to be set, with
+     * additional interceptors
+     * and properties. This clears the cached Retrofit client instances so should
+     * only be called when
      * an actual builder change is required.
      *
      * @param builder is the OkHttpClient.Builder to be used in Retrofit instances
@@ -1072,13 +1185,20 @@ public class ApproovService {
     }
 
     /**
-     * Gets a Retrofit instance that enables the Approov service. The builder for Retrofit should
-     * be provided to allow its customization. This simply adds the underlying OkHttpClient to be
-     * used. Approov tokens are added in headers to requests, and connections are also pinned.
-     * Retrofit instances are added lazily on demand but are cached if there is no change.
-     * lazily on demand but is cached if there are no changes. Note that once constructed and
-     * passed to this method, Retrofit builder instances should not be changed further. If any
-     * changes are required then a new builder should be constructed. Use "setOkHttpClientBuilder"
+     * Gets a Retrofit instance that enables the Approov service. The builder for
+     * Retrofit should
+     * be provided to allow its customization. This simply adds the underlying
+     * OkHttpClient to be
+     * used. Approov tokens are added in headers to requests, and connections are
+     * also pinned.
+     * Retrofit instances are added lazily on demand but are cached if there is no
+     * change.
+     * lazily on demand but is cached if there are no changes. Note that once
+     * constructed and
+     * passed to this method, Retrofit builder instances should not be changed
+     * further. If any
+     * changes are required then a new builder should be constructed. Use
+     * "setOkHttpClientBuilder"
      * to provide any special properties for the underlying OkHttpClient.
      *
      * @param builder is the Retrofit.Builder for required client instance
@@ -1112,7 +1232,7 @@ public class ApproovService {
                 Log.d(TAG, "Building new Approov OkHttpClient");
                 ApproovTokenInterceptor tokenInterceptor = new ApproovTokenInterceptor();
                 okHttpClient = okHttpBuilder.addInterceptor(tokenInterceptor)
-                                .addNetworkInterceptor(pinningInterceptor).build();
+                        .addNetworkInterceptor(pinningInterceptor).build();
             } else {
                 if (isInitialized()) {
                     Log.i(TAG, "Building basic OkHttpClient (Approov bypass mode)");
@@ -1143,7 +1263,7 @@ final class PrefetchCallbackHandler implements Approov.TokenFetchCallback {
     @Override
     public void approovCallback(Approov.TokenFetchResult result) {
         if ((result.getStatus() == Approov.TokenFetchStatus.SUCCESS) ||
-            (result.getStatus() == Approov.TokenFetchStatus.UNKNOWN_URL)) {
+                (result.getStatus() == Approov.TokenFetchStatus.UNKNOWN_URL)) {
             Log.d(TAG, "Prefetch success");
         } else {
             Log.e(TAG, "Prefetch failure: " + result.getStatus().toString());
@@ -1157,7 +1277,8 @@ class ApproovTokenInterceptor implements Interceptor {
     private final static String TAG = "ApproovTokenInterceptor";
 
     /**
-     * Constructs a new interceptor that adds Approov tokens and substitutes headers or query
+     * Constructs a new interceptor that adds Approov tokens and substitutes headers
+     * or query
      * parameters.
      */
     public ApproovTokenInterceptor() {
@@ -1210,11 +1331,14 @@ class ApproovTokenInterceptor implements Interceptor {
 
         // Fetch token using double-checked locking on the failure cache.
         // Fast path: cached failure returned immediately (no lock).
-        // Slow path: gate ensures only one thread refreshes failure state; others wait and re-check.
+        // Slow path: gate ensures only one thread refreshes failure state; others wait
+        // and re-check.
         Approov.TokenFetchResult approovResults = ApproovService.fetchApproovTokenWithGate(url.toString());
 
-        // provide information about the obtained token or error (note "approov token -check" can
-        // be used to check the validity of the token and if you use token annotations they
+        // provide information about the obtained token or error (note "approov token
+        // -check" can
+        // be used to check the validity of the token and if you use token annotations
+        // they
         // will appear here to determine why a request is being rejected)
         Log.d(TAG, "Token for " + url.toString() + ": " + approovResults.getLoggableToken());
 
@@ -1264,14 +1388,17 @@ class ApproovTokenInterceptor implements Interceptor {
                 setTraceIDHeaderValue = traceID;
             }
         } else {
-            // we only continue additional processing if we had a valid status from Approov, to prevent additional delays
-            // by trying to fetch from Approov again and this also protects against header substitutions in domains not
+            // we only continue additional processing if we had a valid status from Approov,
+            // to prevent additional delays
+            // by trying to fetch from Approov again and this also protects against header
+            // substitutions in domains not
             // protected by Approov and therefore potential subject to a MitM
             // setTokenHeaderKey and setTokenHeaderValue must be null
             return chain.proceed(request);
         }
 
-        // we now deal with any header substitutions, which may require further fetches but these
+        // we now deal with any header substitutions, which may require further fetches
+        // but these
         // should be using cached results
         Map<String, String> setSubstitutionHeaders = new java.util.LinkedHashMap<>();
         String originalURL = request.url().toString();
@@ -1294,7 +1421,8 @@ class ApproovTokenInterceptor implements Interceptor {
                 }
             }
 
-            // we now deal with any query parameter substitutions, which may require further fetches but these
+            // we now deal with any query parameter substitutions, which may require further
+            // fetches but these
             // should be using cached results
             Map<String, Pattern> substitutionQueryParams = ApproovService.getSubstitutionQueryParams();
             queryKeys = new ArrayList<>(substitutionQueryParams.size());
@@ -1303,11 +1431,13 @@ class ApproovTokenInterceptor implements Interceptor {
                 Pattern pattern = entry.getValue();
                 Matcher matcher = pattern.matcher(replacementURL);
                 if (matcher.find()) {
-                    // we have found an occurrence of the query parameter to be replaced so we look up the existing
+                    // we have found an occurrence of the query parameter to be replaced so we look
+                    // up the existing
                     // value as a key for a secure string
                     String queryValue = matcher.group(1);
                     approovResults = Approov.fetchSecureStringAndWait(queryValue, null);
-                    Log.d(TAG, "Substituting query parameter: " + queryKey + ", " + approovResults.getStatus().toString());
+                    Log.d(TAG,
+                            "Substituting query parameter: " + queryKey + ", " + approovResults.getStatus().toString());
                     if (mutator.handleInterceptorQueryParamSubstitutionResult(approovResults, queryKey)) {
                         // substitute the query parameter
                         aChange = true;
@@ -1353,21 +1483,24 @@ class ApproovTokenInterceptor implements Interceptor {
     }
 }
 
-
 // interceptor to implement pinning on network connections
 class ApproovPinningInterceptor implements Interceptor {
     // logging tag
     private final static String TAG = "ApproovPinningInterceptor";
 
-    // maximum number of elements that may be held in the handshake cache to allow caching
-    // of different concurrent connections but without causing a significant memory leak
+    // maximum number of elements that may be held in the handshake cache to allow
+    // caching
+    // of different concurrent connections but without causing a significant memory
+    // leak
     private final static int maxCachedHandshakes = 10;
 
-    // the certificate pinner to use for pinning that may be rebuilt if there is a change
+    // the certificate pinner to use for pinning that may be rebuilt if there is a
+    // change
     // in the pinning configuration
     private CertificatePinner certificatePinner;
 
-    // set of TLS handshakes that are known to be valid constrained to a size of maxCachedHandshakes
+    // set of TLS handshakes that are known to be valid constrained to a size of
+    // maxCachedHandshakes
     // to prevent a memory leak for long running apps
     private java.util.LinkedHashSet<Handshake> knownValidHandshakes;
 
@@ -1380,14 +1513,16 @@ class ApproovPinningInterceptor implements Interceptor {
     }
 
     /**
-     * Rebuild the pinning configuration. This is called when the dynamic configuration
-     * changes and we need to update the pinning information. This forces all known valid
+     * Rebuild the pinning configuration. This is called when the dynamic
+     * configuration
+     * changes and we need to update the pinning information. This forces all known
+     * valid
      * handshakes to be cleared.
      */
     synchronized public void buildPins() {
         CertificatePinner.Builder pinBuilder = new CertificatePinner.Builder();
         Map<String, List<String>> allPins = Approov.getPins("public-key-sha256");
-        for (Map.Entry<String, List<String>> entry: allPins.entrySet()) {
+        for (Map.Entry<String, List<String>> entry : allPins.entrySet()) {
             String domain = entry.getKey();
             if (!domain.equals("*")) {
                 // the * domain is for managed trust roots and should
@@ -1399,7 +1534,7 @@ class ApproovPinningInterceptor implements Interceptor {
                     pins = allPins.get("*");
 
                 // add the required pins for the domain
-                for (String pin: pins)
+                for (String pin : pins)
                     pinBuilder = pinBuilder.add(domain, "sha256/" + pin);
             }
         }
@@ -1408,7 +1543,8 @@ class ApproovPinningInterceptor implements Interceptor {
     }
 
     /**
-     * Gets the current CertificatePinner for checking peer certificate on a TLS handshake.
+     * Gets the current CertificatePinner for checking peer certificate on a TLS
+     * handshake.
      *
      * @return the current CertificatePinner
      */
@@ -1417,7 +1553,8 @@ class ApproovPinningInterceptor implements Interceptor {
     }
 
     /**
-     * Determines if the given handshake is known to be valid, supporting different TLS
+     * Determines if the given handshake is known to be valid, supporting different
+     * TLS
      * negotiations on different domains as required.
      *
      * @param handshake ot be checked
@@ -1428,7 +1565,8 @@ class ApproovPinningInterceptor implements Interceptor {
     }
 
     /**
-     * Adds a valid handshake to the cached set, clearing the cache if that would exceed
+     * Adds a valid handshake to the cached set, clearing the cache if that would
+     * exceed
      * the maximum size.
      *
      * @param handshake to be added as known valid

--- a/approov-service/src/main/java/io/approov/service/retrofit/ApproovService.java
+++ b/approov-service/src/main/java/io/approov/service/retrofit/ApproovService.java
@@ -161,6 +161,8 @@ public class ApproovService {
      * @param comment the comment string, or empty for no comment
      */
     public static synchronized void initialize(Context context, String config, String comment) {
+        if (config == null)
+            throw new IllegalArgumentException("config must not be null; pass \"\" for bypass mode");
         // Reset service layer state
         isInitialized = false;
         proceedOnNetworkFail = false;

--- a/approov-service/src/main/java/io/approov/service/retrofit/ApproovService.java
+++ b/approov-service/src/main/java/io/approov/service/retrofit/ApproovService.java
@@ -1084,7 +1084,7 @@ public class ApproovService {
      * Gets the last ARC (Attestation Response Code) code.
      *
      * Always resolves with a string (ARC or empty string).
-     * NOTE: You MUST only call this method upon succesfull attestation completion.
+     * NOTE: You MUST only call this method upon successful attestation completion.
      * Any networking
      * errors returned from the service layer will not return a meaningful ARC code
      * if the method is called!!!

--- a/approov-service/src/main/java/io/approov/service/retrofit/ApproovService.java
+++ b/approov-service/src/main/java/io/approov/service/retrofit/ApproovService.java
@@ -158,7 +158,7 @@ public class ApproovService {
      *
      * @param context the Application context
      * @param config  the configuration string, or empty for no SDK initialization
-     * @param comment the comment string, or empty for no comment
+     * @param comment the comment string, or null for no comment
      */
     public static synchronized void initialize(Context context, String config, String comment) {
         if (config == null)

--- a/approov-service/src/main/java/io/approov/service/retrofit/ApproovService.java
+++ b/approov-service/src/main/java/io/approov/service/retrofit/ApproovService.java
@@ -1422,8 +1422,14 @@ class ApproovTokenInterceptor implements Interceptor {
                     approovResults = Approov.fetchSecureStringAndWait(value.substring(prefix.length()), null);
                     Log.d(TAG, "Substituting header: " + header + ", " + approovResults.getStatus().toString());
                     if (mutator.handleInterceptorHeaderSubstitutionResult(approovResults, header)) {
-                        aChange = true;
-                        setSubstitutionHeaders.put(header, prefix + approovResults.getSecureString());
+                        // Only overwrite the header when a non-empty secure string is available.
+                        // A null or empty result means substitution yielded no value; the original
+                        // placeholder is preserved in place (TESTING_REQUIREMENTS §2 Missing Artifacts Fallback).
+                        String secureString = approovResults.getSecureString();
+                        if (secureString != null && !secureString.isEmpty()) {
+                            aChange = true;
+                            setSubstitutionHeaders.put(header, prefix + secureString);
+                        }
                     }
                 }
             }
@@ -1446,11 +1452,16 @@ class ApproovTokenInterceptor implements Interceptor {
                     Log.d(TAG,
                             "Substituting query parameter: " + queryKey + ", " + approovResults.getStatus().toString());
                     if (mutator.handleInterceptorQueryParamSubstitutionResult(approovResults, queryKey)) {
-                        // substitute the query parameter
-                        aChange = true;
-                        queryKeys.add(queryKey);
-                        replacementURL = new StringBuilder(replacementURL).replace(matcher.start(1),
-                                matcher.end(1), approovResults.getSecureString()).toString();
+                        // Only substitute when a non-empty secure string is available.
+                        // A null or empty result means substitution yielded no value; the original
+                        // placeholder is preserved in place (TESTING_REQUIREMENTS §2 Missing Artifacts Fallback).
+                        String secureString = approovResults.getSecureString();
+                        if (secureString != null && !secureString.isEmpty()) {
+                            aChange = true;
+                            queryKeys.add(queryKey);
+                            replacementURL = new StringBuilder(replacementURL).replace(matcher.start(1),
+                                    matcher.end(1), secureString).toString();
+                        }
                     }
                 }
             }

--- a/approov-service/src/main/java/io/approov/service/retrofit/ApproovService.java
+++ b/approov-service/src/main/java/io/approov/service/retrofit/ApproovService.java
@@ -163,7 +163,25 @@ public class ApproovService {
     public static synchronized void initialize(Context context, String config, String comment) {
         if (config == null)
             throw new IllegalArgumentException("config must not be null; pass \"\" for bypass mode");
-        // Reset service layer state
+
+        // Initialize the platform SDK if not in bypass mode (empty config).
+        // State is only modified after the SDK confirms success, preserving the current
+        // operating mode (protected or bypass) if the call fails.
+        if (!config.isEmpty()) {
+            try {
+                boolean sdkInitialized = Approov.initialize(context.getApplicationContext(), config, "auto", comment);
+                if (!sdkInitialized) {
+                    Log.d(TAG, "Approov SDK already initialized");
+                }
+            } catch (IllegalArgumentException e) {
+                Log.e(TAG, "Approov initialization failed: " + e.getMessage());
+                throw e; // service-layer state NOT modified — prior operating mode preserved
+            } catch (IllegalStateException e) {
+                Log.e(TAG, "Approov initialization failed: " + e.getMessage());
+                throw e; // service-layer state NOT modified — prior operating mode preserved
+            }
+        }
+        // SDK succeeded (or bypass) — now reset and commit new service-layer state.
         isInitialized = false;
         proceedOnNetworkFail = false;
         useApproovStatusIfNoToken = false;
@@ -180,26 +198,6 @@ public class ApproovService {
         synchronized (failureCacheLock) {
             cachedFailureResult = null;
             cachedFailureTimeMs = 0;
-        }
-
-        // Initialize the platform SDK if not in bypass mode (empty config).
-        // The SDK returns true if initialization succeeded, false if already
-        // initialized
-        // with the same config even by another service layer instance. Any other
-        // failure (e.g. different config) throws.
-        if (!config.isEmpty()) {
-            try {
-                boolean sdkInitialized = Approov.initialize(context.getApplicationContext(), config, "auto", comment);
-                if (!sdkInitialized) {
-                    Log.d(TAG, "Approov SDK already initialized");
-                }
-            } catch (IllegalArgumentException e) {
-                Log.e(TAG, "Approov initialization failed: " + e.getMessage());
-                throw e;
-            } catch (IllegalStateException e) {
-                Log.e(TAG, "Approov initialization failed: " + e.getMessage());
-                throw e;
-            }
         }
         if (!config.isEmpty())
             pinningInterceptor = new ApproovPinningInterceptor();

--- a/approov-service/src/main/java/io/approov/service/retrofit/ApproovService.java
+++ b/approov-service/src/main/java/io/approov/service/retrofit/ApproovService.java
@@ -164,6 +164,13 @@ public class ApproovService {
         if (config == null)
             throw new IllegalArgumentException("config must not be null; pass \"\" for bypass mode");
 
+        // If we are already initialized with a valid config, ignore any subsequent
+        // empty config initialization
+        if (isInitialized && configString != null && !configString.isEmpty() && config.isEmpty()) {
+            Log.d(TAG, "ApproovService already initialized with a valid config; ignoring empty configuration");
+            return;
+        }
+
         // Initialize the platform SDK if not in bypass mode (empty config).
         // State is only modified after the SDK confirms success, preserving the current
         // operating mode (protected or bypass) if the call fails.

--- a/approov-service/src/main/java/io/approov/service/retrofit/ApproovService.java
+++ b/approov-service/src/main/java/io/approov/service/retrofit/ApproovService.java
@@ -155,10 +155,48 @@ public class ApproovService {
 
     /**
      * Initializes the ApproovService with an account configuration and comment.
+     * <p>
+     * <b>Configuration identity is owned by the native Approov SDK, not this layer.</b> Any
+     * non-empty {@code config} is forwarded directly to {@code Approov.initialize}; this layer
+     * does not compare it against the previous configuration. The native SDK returns {@code false}
+     * when it is already initialized with the same configuration (treated here as success), and
+     * throws {@code IllegalStateException} for a different configuration unless a
+     * {@code reinit}-prefixed {@code comment} forces re-initialization.
+     * <p>
+     * <b>Service-layer state is changed only on success.</b> If the native SDK rejects the call,
+     * this layer is left completely unchanged and keeps operating in whatever mode it was in
+     * (protected or bypass). On success — including the benign same-config no-op — this layer
+     * resets <i>all</i> of its own configuration back to defaults (token header and prefix,
+     * trace-ID header, binding header, substitution headers and query params, exclusion regexes,
+     * the service mutator, and the {@code proceedOnNetworkFail} / {@code useApproovStatusIfNoToken}
+     * flags) and then re-commits. Follow the "initialize once, then configure" contract: anything
+     * applied via {@code setApproovTokenHeader}, {@code addSubstitutionHeader},
+     * {@code addExclusionURLRegex}, {@code setServiceMutator}, etc. must be (re)applied <i>after</i>
+     * this call, otherwise a later re-initialization will silently discard it (a warning is logged
+     * when a re-init discards state).
+     * <p>
+     * Behavior by prior state and {@code config} (the {@code comment} is forwarded to the native
+     * SDK — use {@code "reinit…"} to re-initialize with a changed config, {@code "options:…"} for
+     * startup options):
+     * <pre>
+     *   prior state   config       outcome
+     *   ───────────   ──────────   ──────────────────────────────────────────────────
+     *   uninit        empty        bypass mode (native SDK not initialized)
+     *   uninit        valid        protected mode
+     *   uninit        invalid      throws, stays uninitialized
+     *   bypass        empty        stays bypass, state reset
+     *   bypass        valid        upgrades to protected, state reset
+     *   protected     empty        ignored, state preserved (cannot be downgraded)
+     *   protected     same valid   benign no-op (SDK returns false), state reset
+     *   protected     different    throws IllegalStateException, state preserved
+     * </pre>
      *
      * @param context the Application context
-     * @param config  the configuration string, or empty for no SDK initialization
-     * @param comment the comment string, or null for no comment
+     * @param config  the configuration string, or empty ({@code ""}) for bypass mode; must not be null
+     * @param comment the comment forwarded to the native SDK (e.g. {@code "options:…"} on first
+     *                init, or {@code "reinit…"} to re-initialize), or null for no comment
+     * @throws IllegalArgumentException if {@code config} is null or the native SDK rejects it
+     * @throws IllegalStateException    if the native SDK is already initialized with a different config
      */
     public static synchronized void initialize(Context context, String config, String comment) {
         if (config == null)
@@ -189,6 +227,13 @@ public class ApproovService {
             }
         }
         // SDK succeeded (or bypass) — now reset and commit new service-layer state.
+        // A re-initialization discards any service-layer configuration applied since the previous
+        // initialize. Warn so this is visible, per the "initialize once, then configure" contract.
+        if (isInitialized) {
+            Log.w(TAG, "Re-initializing ApproovService: discarding previously applied service-layer "
+                    + "configuration (token headers, substitutions, exclusions, mutator, flags). "
+                    + "Re-apply any custom configuration after this call.");
+        }
         isInitialized = false;
         proceedOnNetworkFail = false;
         useApproovStatusIfNoToken = false;

--- a/approov-service/src/test/java/io/approov/service/retrofit/ApproovServiceContractTest.java
+++ b/approov-service/src/test/java/io/approov/service/retrofit/ApproovServiceContractTest.java
@@ -79,9 +79,17 @@ public class ApproovServiceContractTest {
             assertTrue(stockClient.networkInterceptors().stream().noneMatch(interceptor -> interceptor instanceof ApproovPinningInterceptor));
             assertTrue(protectedClient.interceptors().stream().anyMatch(interceptor -> interceptor instanceof ApproovTokenInterceptor));
             assertTrue(protectedClient.networkInterceptors().stream().anyMatch(interceptor -> interceptor instanceof ApproovPinningInterceptor));
-            approov.verify(() -> Approov.initialize(context, "dummy-config", "auto", ""));
+            approov.verify(() -> Approov.initialize(context, "dummy-config", "auto", null));
             approov.verify(() -> Approov.setUserProperty("approov-service-retrofit"));
         }
+    }
+
+    @Test
+    public void initializeWithNullConfigAndCommentSucceedsAsBypass() {
+        Context context = mock(Context.class);
+        ApproovService.initialize(context, null, null);
+        assertTrue(ApproovService.isInitialized());
+        assertFalse(ApproovService.isApproovEnabled());
     }
 
     @Test

--- a/approov-service/src/test/java/io/approov/service/retrofit/ApproovServiceContractTest.java
+++ b/approov-service/src/test/java/io/approov/service/retrofit/ApproovServiceContractTest.java
@@ -80,7 +80,7 @@ public class ApproovServiceContractTest {
             assertTrue(protectedClient.interceptors().stream().anyMatch(interceptor -> interceptor instanceof ApproovTokenInterceptor));
             assertTrue(protectedClient.networkInterceptors().stream().anyMatch(interceptor -> interceptor instanceof ApproovPinningInterceptor));
             approov.verify(() -> Approov.initialize(context, "dummy-config", "auto", null));
-            approov.verify(() -> Approov.setUserProperty("approov-service-retrofit"));
+            approov.verify(() -> Approov.setUserProperty("approov-service-retrofit/" + BuildConfig.APPROOV_SERVICE_VERSION));
         }
     }
 
@@ -136,7 +136,7 @@ public class ApproovServiceContractTest {
             ApproovService.setApproovTraceIDHeader(null);
 
             assertEquals(null, ApproovService.getApproovTraceIDHeader());
-            approov.verify(() -> Approov.setUserProperty("approov-service-retrofit"));
+            approov.verify(() -> Approov.setUserProperty("approov-service-retrofit/" + BuildConfig.APPROOV_SERVICE_VERSION));
         }
     }
 

--- a/approov-service/src/test/java/io/approov/service/retrofit/ApproovServiceContractTest.java
+++ b/approov-service/src/test/java/io/approov/service/retrofit/ApproovServiceContractTest.java
@@ -85,11 +85,10 @@ public class ApproovServiceContractTest {
     }
 
     @Test
-    public void initializeWithNullConfigAndCommentSucceedsAsBypass() {
+    public void initializeWithNullConfigThrowsIllegalArgument() {
         Context context = mock(Context.class);
-        ApproovService.initialize(context, null, null);
-        assertTrue(ApproovService.isInitialized());
-        assertFalse(ApproovService.isApproovEnabled());
+        assertThrows(IllegalArgumentException.class, () -> ApproovService.initialize(context, null, null));
+        assertFalse(ApproovService.isInitialized());
     }
 
     @Test

--- a/approov-service/src/test/java/io/approov/service/retrofit/ApproovServiceMiniSdkTest.java
+++ b/approov-service/src/test/java/io/approov/service/retrofit/ApproovServiceMiniSdkTest.java
@@ -93,7 +93,13 @@ public class ApproovServiceMiniSdkTest {
     public void testInitializeWithEmptyConfigBuildsPlainClient() throws Exception {
         reinitializeService(scenarioJson(uniqueCaseName("empty-config"),
             "\"protectedDomains\": [\"" + getTargetHost() + "\"]"));
-        ApproovService.initialize(context, "", "reinit-empty-config");
+        // Drop the service layer back to an uninitialized state so this exercises a genuine
+        // first-time empty-config (bypass) initialization. A service layer already protected with
+        // a valid config cannot be downgraded to bypass by a later empty config
+        // (TESTING_REQUIREMENTS §1 "Empty Configuration after Valid Configuration"); that case is
+        // covered by testInitializeWithValidThenEmptyConfigIgnoresEmptyConfig.
+        ApproovTestSupport.resetApproovServiceState();
+        ApproovService.initialize(context, "");
 
         assertTrue(ApproovService.isInitialized());
         assertFalse(ApproovService.isApproovEnabled());
@@ -121,7 +127,11 @@ public class ApproovServiceMiniSdkTest {
     public void testInitializeWithEmptyConfigCanLaterEnableApproov() throws Exception {
         reinitializeService(scenarioJson(uniqueCaseName("empty-then-valid"),
             "\"protectedDomains\": [\"" + getTargetHost() + "\"]"));
-        ApproovService.initialize(context, "", "reinit-empty-config");
+        // Start from an uninitialized service layer so the empty config is a genuine first-time
+        // bypass initialization (an already-protected layer would ignore the empty config —
+        // TESTING_REQUIREMENTS §1). This then verifies the bypass→protected upgrade path.
+        ApproovTestSupport.resetApproovServiceState();
+        ApproovService.initialize(context, "");
 
         assertTrue(ApproovService.isInitialized());
         assertFalse(ApproovService.isApproovEnabled());

--- a/approov-service/src/test/java/io/approov/service/retrofit/ApproovServiceMiniSdkTest.java
+++ b/approov-service/src/test/java/io/approov/service/retrofit/ApproovServiceMiniSdkTest.java
@@ -63,21 +63,22 @@ public class ApproovServiceMiniSdkTest {
     /**
      * §1 Same Config Re-initialization / Different Config Re-initialization
      *
-     * Re-initialize with the same config string should not fail.
-     * Re-initialize with a different config string should fail with an exception.
+     * Re-initialize with the same config string should not fail (platform SDK returns false).
+     * Re-initialize with a different config string should fail: the platform SDK throws
+     * IllegalStateException which is re-thrown by the service layer.
      */
     @Test
     public void testInitializeIgnoresSameConfigAndRejectsDifferentConfig() {
-        // Re-init with same config should be ignored (no exception)
+        // Re-init with same config: SDK returns false, service layer logs and continues
         ApproovService.initialize(context, validInitialConfig);
 
-        // Re-init with different config should throw illegal state
+        // Re-init with different config: platform SDK throws IllegalStateException
         String differentConfig = "#cb-other#mAxOF0ekJUOC36J5XWmVmVipOcUoEdMjhPSp2FVtyTo=";
         try {
             ApproovService.initialize(context, differentConfig);
             fail("Expected IllegalStateException");
         } catch (IllegalStateException e) {
-            assertEquals("ApproovService layer is already initialized.", e.getMessage());
+            assertNotNull(e.getMessage());
         }
     }
 

--- a/approov-service/src/test/java/io/approov/service/retrofit/ApproovServiceMiniSdkTest.java
+++ b/approov-service/src/test/java/io/approov/service/retrofit/ApproovServiceMiniSdkTest.java
@@ -146,6 +146,30 @@ public class ApproovServiceMiniSdkTest {
         }
     }
 
+    @Test
+    public void testInitializeWithValidThenEmptyConfigIgnoresEmptyConfig() throws Exception {
+        reinitializeService(scenarioJson(uniqueCaseName("valid-then-empty"),
+            "\"protectedDomains\": [\"" + getTargetHost() + "\"]"));
+
+        // Initialize with a valid config
+        ApproovService.initialize(context, validInitialConfig);
+        assertTrue(ApproovService.isInitialized());
+        assertTrue(ApproovService.isApproovEnabled());
+
+        // Reinitialize with an empty config (should be ignored)
+        ApproovService.initialize(context, "", "reinit-empty-config");
+        assertTrue(ApproovService.isInitialized());
+        assertTrue(ApproovService.isApproovEnabled());
+
+        // Verify that requests are still protected
+        OkHttpClient client = getOkHttpClientFromRetrofit();
+        try (Response response = client.newCall(new Request.Builder().url(getTargetURL()).build()).execute()) {
+            assertTrue(response.isSuccessful());
+            JSONObject reply = new JSONObject(response.body().string());
+            assertNotNull(getHeader(reply, "Approov-Token"));
+        }
+    }
+
     // ==================================================================================
     // SECTION 2: Request Processing & Token Behaviors
     // TESTING_REQUIREMENTS.md §2


### PR DESCRIPTION
## Description

This PR hardens the Retrofit service layer with zero-config R8 compatibility, BouncyCastle relocation, initialization robustness improvements, and documentation updates.

### R8 / ProGuard Hardening

- **Zero-config R8 rules**: Added `consumer-rules.pro` with keep rules for Approov SDK, BouncyCastle, and message signing classes. These are automatically applied to consuming apps via `consumerProguardFiles`, eliminating the need for manual ProGuard configuration.
- **BouncyCastle relocation**: Relocated BouncyCastle to `io.approov.internal.retrofit.bouncycastle` using the Shadow Gradle plugin to avoid classpath conflicts with apps that bundle their own BouncyCastle version.

### Initialization Robustness

- **Simplified initialization**: Delegated re-initialization decisions to the native platform SDK instead of maintaining complex local state tracking. The service layer now forwards the call and interprets the SDK response.
- **Null config rejection**: `initialize(null)` now throws `IllegalArgumentException` with a clear message instead of silently failing.
- **Empty-config bypass guard**: When already initialized with a valid config, a subsequent empty-config call is silently ignored — the service layer cannot be downgraded from protected to bypass mode.
- **State preservation on failure**: SDK initialization failure no longer wipes the existing service-layer state — the previous operating mode (protected or bypass) is fully preserved.
- **Comment/options support**: `initialize` now accepts a `comment` parameter forwarded to the native SDK for `options:` and `reinit` flows, documented in REFERENCE.md.

### Documentation

- **README.md**: Integrated quickstart content directly into the README for a self-contained onboarding experience.
- **REFERENCE.md**: Documented `initialize` comment options, reinitialization semantics, and null/empty config behavior.
- **CHANGELOG.md**: Added entries for all changes.
- **LICENSE**: Updated copyright year.

### CI

- Removed hardcoded worker URL fallbacks from the build and test workflow.

## Files Changed

| File | Change |
|:---|:---|
| `ApproovService.java` | Initialization rewrite, null guard, empty-config bypass, state preservation |
| `consumer-rules.pro` | New — zero-config R8 keep rules |
| `build.gradle` | Shadow plugin for BouncyCastle relocation, consumer ProGuard rules |
| `pom.xml` | Version updates |
| `ApproovDefaultMessageSigning.java` | Minor adjustments for relocated BouncyCastle |
| `README.md` | Integrated quickstart content |
| `REFERENCE.md` | Initialization docs update |
| `CHANGELOG.md` | New entries |
| `ApproovServiceContractTest.java` | Test updates for new initialization behavior |
| `ApproovServiceMiniSdkTest.java` | Test updates for null config and empty-config flows |

Related: approov/core-project-approov#558
