### PR TITLE
ci: release.yml with README auto-bump and post-tag README guard

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -31,6 +31,8 @@ jobs:
       
     - name: Checkout Repository
       uses: actions/checkout@v5
+      with:
+        persist-credentials: false
 
     # Fail fast if the release tag and the CHANGELOG have drifted, before any
     # build or publish work. The top "## [x.y.z]" entry must match the tag.
@@ -50,15 +52,26 @@ jobs:
         fi
         echo "CHANGELOG.md top entry matches tag: $TAG"
 
-    # Guard: README dependency snippet must match the release tag.
-    # The intended release path is release.yml, which auto-bumps README before tagging.
-    # This step catches manual tag pushes that bypass that workflow.
+    # Guard: every README dependency snippet must match the release tag.
     - name: Verify README matches tag
       run: |
+        set -euo pipefail
         TAG="${{ github.ref_name }}"
-        grep -qF "service.retrofit:${TAG}" README.md \
-          || { echo "::error::README.md dependency snippet does not match tag ${TAG}. Use release.yml to tag — it auto-bumps README automatically."; exit 1; }
-        echo "README.md dependency version matches tag: ${TAG}"
+        SEMVER='[0-9]+\.[0-9]+\.[0-9]+'
+        README_VERSIONS=$(grep -oE "service\.retrofit:${SEMVER}([A-Za-z0-9._-]+)?" README.md | sort -u) || true
+        EXPECTED_VERSION="service.retrofit:${TAG}"
+        if [ -z "$README_VERSIONS" ]; then
+          echo "::error::Could not find a service.retrofit dependency version in README.md"
+          exit 1
+        fi
+        if [ "$README_VERSIONS" != "$EXPECTED_VERSION" ]; then
+          echo "::error::README.md service.retrofit versions do not all match tag ${TAG}"
+          echo "Expected: ${EXPECTED_VERSION}"
+          echo "Found:"
+          printf '%s\n' "$README_VERSIONS"
+          exit 1
+        fi
+        echo "README.md dependency versions match tag: ${TAG}"
 
     - name: Set Up Java
       uses: actions/setup-java@v5

--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -32,6 +32,18 @@ jobs:
     - name: Checkout Repository
       uses: actions/checkout@v5
 
+    # Guard: README dependency snippet must match the release tag.
+    # The intended release path is release.yml, which auto-bumps README before tagging.
+    # This step catches manual tag pushes that bypass that workflow.
+    # Once PR #24 merges (adding "Verify CHANGELOG matches tag"), move this step to
+    # immediately after that one.
+    - name: Verify README matches tag
+      run: |
+        TAG="${{ github.ref_name }}"
+        grep -qF "service.retrofit:${TAG}" README.md \
+          || { echo "::error::README.md dependency snippet does not match tag ${TAG}. Use release.yml to tag — it auto-bumps README automatically."; exit 1; }
+        echo "README.md dependency version matches tag: ${TAG}"
+
     # Fail fast if the release tag and the CHANGELOG have drifted, before any
     # build or publish work. The top "## [x.y.z]" entry must match the tag.
     - name: Verify CHANGELOG matches tag

--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -32,18 +32,6 @@ jobs:
     - name: Checkout Repository
       uses: actions/checkout@v5
 
-    # Guard: README dependency snippet must match the release tag.
-    # The intended release path is release.yml, which auto-bumps README before tagging.
-    # This step catches manual tag pushes that bypass that workflow.
-    # Once PR #24 merges (adding "Verify CHANGELOG matches tag"), move this step to
-    # immediately after that one.
-    - name: Verify README matches tag
-      run: |
-        TAG="${{ github.ref_name }}"
-        grep -qF "service.retrofit:${TAG}" README.md \
-          || { echo "::error::README.md dependency snippet does not match tag ${TAG}. Use release.yml to tag — it auto-bumps README automatically."; exit 1; }
-        echo "README.md dependency version matches tag: ${TAG}"
-
     # Fail fast if the release tag and the CHANGELOG have drifted, before any
     # build or publish work. The top "## [x.y.z]" entry must match the tag.
     - name: Verify CHANGELOG matches tag
@@ -61,6 +49,16 @@ jobs:
           exit 1
         fi
         echo "CHANGELOG.md top entry matches tag: $TAG"
+
+    # Guard: README dependency snippet must match the release tag.
+    # The intended release path is release.yml, which auto-bumps README before tagging.
+    # This step catches manual tag pushes that bypass that workflow.
+    - name: Verify README matches tag
+      run: |
+        TAG="${{ github.ref_name }}"
+        grep -qF "service.retrofit:${TAG}" README.md \
+          || { echo "::error::README.md dependency snippet does not match tag ${TAG}. Use release.yml to tag — it auto-bumps README automatically."; exit 1; }
+        echo "README.md dependency version matches tag: ${TAG}"
 
     - name: Set Up Java
       uses: actions/setup-java@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout main
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: main
           fetch-depth: 0
@@ -44,7 +44,6 @@ jobs:
           echo "Releasing version: $VERSION"
 
           # 2. Refuse if already tagged.
-          git fetch --tags --quiet
           if git rev-parse -q --verify "refs/tags/$VERSION" >/dev/null; then
             echo "::error::$VERSION is already tagged. Did you forget to add a new CHANGELOG entry for this release?"
             exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,72 @@
+name: Release Current Main Branch
+
+# Manual release — the single place that tags main.
+#
+# Run from the Actions tab against main once main is known good.
+# It:
+#   1. reads the top CHANGELOG version (## [x.y.z]);
+#   2. refuses if that version is already tagged;
+#   3. auto-bumps the README dependency snippet to match (CHANGELOG is sole source of truth);
+#   4. commits the bump to main if needed (with [skip ci] to suppress test runs); and
+#   5. tags main's HEAD with the version and pushes the tag,
+#      which fires build_and_publish.yml to build and publish to Maven Central.
+#
+# Tagging stays manual — the workflow_dispatch is the release decision point.
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Validate, auto-bump README, and tag
+        run: |
+          set -uo pipefail
+          SEMVER='[0-9]+\.[0-9]+\.[0-9]+'
+
+          # 1. Read top CHANGELOG version — sole source of truth.
+          VERSION=$(grep -m1 -oE "^## \[$SEMVER\]" CHANGELOG.md | grep -oE "$SEMVER") || true
+          if [ -z "$VERSION" ]; then
+            echo "::error::Could not find a version header (## [x.y.z]) in CHANGELOG.md"
+            exit 1
+          fi
+          echo "Releasing version: $VERSION"
+
+          # 2. Refuse if already tagged.
+          git fetch --tags --quiet
+          if git rev-parse -q --verify "refs/tags/$VERSION" >/dev/null; then
+            echo "::error::$VERSION is already tagged. Did you forget to add a new CHANGELOG entry for this release?"
+            exit 1
+          fi
+
+          # 3. Auto-bump README dependency snippet to $VERSION.
+          #    Pattern targets service.retrofit only — cannot match approov-android-sdk.
+          sed -i "s/service\.retrofit:[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*/service.retrofit:${VERSION}/g" README.md
+
+          # 4. Commit the bump if README changed.
+          if ! git diff --quiet README.md; then
+            git config user.name  "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git add README.md
+            git commit -m "chore: bump README dependency to ${VERSION} [skip ci]"
+            git push origin main
+            echo "README.md bumped to ${VERSION} and committed."
+          else
+            echo "README.md already at ${VERSION} — no commit needed."
+          fi
+
+          # 5. Tag HEAD (the bump commit if one was made) and push.
+          git tag "$VERSION"
+          git push origin "$VERSION"
+          echo "Tagged main @ $(git rev-parse --short HEAD) as $VERSION"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,26 +1,24 @@
-name: Release Current Main Branch
+name: Verify Release Readiness
 
-# Manual release — the single place that tags main.
+# Manual release readiness check. This workflow is intentionally read-only:
+# it never commits, tags, or publishes.
 #
-# Run from the Actions tab against main once main is known good.
+# Run from the Actions tab against main after merging a release-prep PR.
 # It:
 #   1. reads the top CHANGELOG version (## [x.y.z]);
 #   2. refuses if that version is already tagged;
-#   3. auto-bumps the README dependency snippet to match (CHANGELOG is sole source of truth);
-#   4. commits the bump to main if needed (with [skip ci] to suppress test runs); and
-#   5. tags main's HEAD with the version and pushes the tag,
-#      which fires build_and_publish.yml to build and publish to Maven Central.
+#   3. verifies every README service.retrofit dependency snippet matches it.
 #
-# Tagging stays manual — the workflow_dispatch is the release decision point.
+# If this passes, push the semver tag manually from main to publish.
 
 on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
-  release:
+  verify:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
@@ -29,10 +27,11 @@ jobs:
         with:
           ref: main
           fetch-depth: 0
+          persist-credentials: false
 
-      - name: Validate, auto-bump README, and tag
+      - name: Verify release readiness
         run: |
-          set -uo pipefail
+          set -euo pipefail
           SEMVER='[0-9]+\.[0-9]+\.[0-9]+'
 
           # 1. Read top CHANGELOG version — sole source of truth.
@@ -41,31 +40,27 @@ jobs:
             echo "::error::Could not find a version header (## [x.y.z]) in CHANGELOG.md"
             exit 1
           fi
-          echo "Releasing version: $VERSION"
+          echo "Verifying release readiness for version: $VERSION"
 
           # 2. Refuse if already tagged.
           if git rev-parse -q --verify "refs/tags/$VERSION" >/dev/null; then
-            echo "::error::$VERSION is already tagged. Did you forget to add a new CHANGELOG entry for this release?"
+            echo "::error::$VERSION is already tagged. Add a new CHANGELOG entry before preparing another release."
             exit 1
           fi
 
-          # 3. Auto-bump README dependency snippet to $VERSION.
-          #    Pattern targets service.retrofit only — cannot match approov-android-sdk.
-          sed -i "s/service\.retrofit:[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*/service.retrofit:${VERSION}/g" README.md
-
-          # 4. Commit the bump if README changed.
-          if ! git diff --quiet README.md; then
-            git config user.name  "github-actions[bot]"
-            git config user.email "github-actions[bot]@users.noreply.github.com"
-            git add README.md
-            git commit -m "chore: bump README dependency to ${VERSION} [skip ci]"
-            git push origin main
-            echo "README.md bumped to ${VERSION} and committed."
-          else
-            echo "README.md already at ${VERSION} — no commit needed."
+          # 3. Every documented service.retrofit dependency must match CHANGELOG.
+          README_VERSIONS=$(grep -oE "service\.retrofit:${SEMVER}([A-Za-z0-9._-]+)?" README.md | sort -u) || true
+          EXPECTED_VERSION="service.retrofit:${VERSION}"
+          if [ -z "$README_VERSIONS" ]; then
+            echo "::error::Could not find a service.retrofit dependency version in README.md"
+            exit 1
           fi
-
-          # 5. Tag HEAD (the bump commit if one was made) and push.
-          git tag "$VERSION"
-          git push origin "$VERSION"
-          echo "Tagged main @ $(git rev-parse --short HEAD) as $VERSION"
+          if [ "$README_VERSIONS" != "$EXPECTED_VERSION" ]; then
+            echo "::error::README.md service.retrofit versions do not all match CHANGELOG version ${VERSION}"
+            echo "Expected: ${EXPECTED_VERSION}"
+            echo "Found:"
+            printf '%s\n' "$README_VERSIONS"
+            exit 1
+          fi
+          echo "README.md dependency versions match CHANGELOG version: ${VERSION}"
+          echo "Release readiness verified. Push tag ${VERSION} manually from main to publish."


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/release.yml` — a manual \`workflow_dispatch\` release workflow that makes \`CHANGELOG.md\` the sole source of truth for the version. On trigger it reads the top CHANGELOG entry, auto-bumps the \`service.retrofit:x.y.z\` dependency snippet in \`README.md\` via \`sed\`, commits to \`main\` if needed (\`[skip ci]\`), then pushes the version tag (which fires \`build_and_publish.yml\`).
- Adds a "Verify README matches tag" step to \`build_and_publish.yml\` as a last-resort guard for manual tag pushes that bypass \`release.yml\`.

## Developer workflow going forward

1. Open a release-prep PR bumping **only the CHANGELOG** top entry. README is now CI-managed — do not update it manually.
2. Merge to main.
3. Actions → "Release Current Main Branch" → Run workflow.
4. CI auto-bumps README, commits (\`[skip ci]\`), tags, and publishes to Maven Central automatically.

## Note on PR #24

The "Verify README matches tag" step in \`build_and_publish.yml\` is currently placed after \`Checkout Repository\`. Once PR #24 merges (adding "Verify CHANGELOG matches tag"), the README step should be moved immediately after the CHANGELOG step — they belong together as the pre-build consistency checks.

## Test plan

- [x] YAML syntax valid for both workflow files
- [x] \`sed\` pattern rewrites both Kotlin and Groovy dependency forms, leaves \`approov-android-sdk\` lines untouched
- [x] CHANGELOG version extraction returns the correct semver string
- [x] \`grep -qF "service.retrofit:TAG" README.md\` passes when README is current, fails when stale

🤖 Generated with [Claude Code](https://claude.com/claude-code)